### PR TITLE
Remove pylint if no backend

### DIFF
--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -215,7 +215,7 @@ repos:
         name: ruff-tests
         args: [--fix, --config=./ruff-test.toml]
         files: tests?/.+\.py$
-      - id: ruff-format
+      - id: ruff-format{% endraw %}{% if has_backend %}{% raw %}
 
   - repo: https://github.com/pylint-dev/pylint
     rev: aaab3ccb541532d2bcdf0410ab93ff4fafc266f5 # frozen: v3.3.5
@@ -224,7 +224,7 @@ repos:
         name: pylint
         args:
           - --rcfile=./pylintrc.toml
-        verbose: true{% endraw %}{% if has_backend %}{% raw %}
+        verbose: true{% endraw %}{% endif %}{% raw %}{% endraw %}{% if has_backend %}{% raw %}
 
   - repo: local
     hooks:


### PR DESCRIPTION
 ## Why is this change necessary?
Running pre-commit fails on pylint if there's no backend present


 ## How does this change address the issue?
Removes pylint from pre-commit if no backend


 ## What side effects does this change have?
None


 ## How is this change tested?
downstream repo
