### PR TITLE
Internal docker compose network

### DIFF
--- a/template/deployment/docker-compose.yaml.jinja
+++ b/template/deployment/docker-compose.yaml.jinja
@@ -6,6 +6,8 @@
       - "4000:4000" # TODO: figure out why the deployed server is ignoring the envvar to set the URL, so that we can change this to `expose: 4000` to only make the backend available within the docker network, don't risk conflicts with a port on the host machine
     pull_policy: never  # Prevents Docker from pulling the image
     restart: unless-stopped
+    networks:
+      - internal_net
 {% endraw %}{% endif %}{% raw %}
   frontend:
     image: 183631337349.dkr.ecr.us-east-1.amazonaws.com/{% endraw %}{{ repo_name }}{% raw %}-frontend:latest
@@ -17,4 +19,10 @@
     environment:
       GRAPHQL_API_URL: http://backend:4000/graphql
     pull_policy: never  # Prevents Docker from pulling the image
-    restart: unless-stopped{% endraw %}
+    restart: unless-stopped
+    networks:
+      - internal_net
+
+networks:
+  internal_net:
+    internal: true # block all outgoing internet access, to mimic the production environment{% endraw %}

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -7,6 +7,8 @@
     ports:
       - "4000:4000"
     restart: unless-stopped
+    networks:
+      - internal_net
 {% endraw %}{% endif %}{% raw %}
   frontend:
     build:
@@ -19,4 +21,10 @@
       - backend{% endraw %}{% endif %}{% raw %}
     environment:
       GRAPHQL_API_URL: http://backend:4000/graphql
-    restart: unless-stopped{% endraw %}
+    restart: unless-stopped
+    networks:
+      - internal_net
+
+networks:
+  internal_net:
+    internal: false # TODO: figure out a way to set this to true (like in deployment) but still trigger the VS Code port-forwarding to easily see the previews{% endraw %}

--- a/template/{% if has_backend %}backend{% endif %}/Dockerfile.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/Dockerfile.jinja
@@ -17,4 +17,4 @@ RUN uv sync --frozen --no-dev && uv pip list
 EXPOSE 4000
 
 # By default, run Uvicorn to serve the GraphQL app
-CMD ["uv", "run", "uvicorn", "graphql_service.app:app", "--host", "0.0.0.0", "--port", "4000"]{% endraw %}
+CMD ["uv", "run", "--no-dev", "uvicorn", "graphql_service.app:app", "--host", "0.0.0.0", "--port", "4000"]{% endraw %}


### PR DESCRIPTION
 ## Why is this change necessary?
The backend container was downloading dev packages from the internet when it started up


 ## How does this change address the issue?
includes the `--no-dev` flag in the `uv run` command
Updates docker-compose file for deployment to use an internal network to prevent any outgoing internet access


 ## What side effects does this change have?
None


 ## How is this change tested?
Before the `-no-dev` flag fix, I tested just the docker compose network, and it succesfully reproduced the problem by erroring when uv attempted to download the libraries on boot-up.
