### PR TITLE
Optional network block

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -90,6 +90,11 @@ frontend_deployed_port_number:
     help: What port should the frontend be deployed to?
     default: 3000
 
+create_internal_docker_compose_network:
+    type: bool
+    help: Should an internal network be created for the Docker Compose services (this will block all access to anything outside the containers)?
+    default: no
+
 # Additional Settings
 _min_copier_version: "9.4"
 

--- a/template/deployment/docker-compose.yaml.jinja
+++ b/template/deployment/docker-compose.yaml.jinja
@@ -25,4 +25,4 @@
 
 networks:
   internal_net:
-    internal: true # block all outgoing internet access, to mimic the production environment{% endraw %}
+    internal: {% endraw %}{% if create_internal_docker_compose_network %}{% raw %}true # block all outgoing internet access, to mimic the production environment{% endraw %}{% else %}{% raw %}false{% endraw %}{% endif %}{% raw %}{% endraw %}

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -27,4 +27,4 @@
 
 networks:
   internal_net:
-    internal: false # TODO: figure out a way to set this to true (like in deployment) but still trigger the VS Code port-forwarding to easily see the previews{% endraw %}
+    internal: {% endraw %}{% if create_internal_docker_compose_network %}{% raw %}false # TODO: figure out a way to set this to true (like in deployment) but still trigger the VS Code port-forwarding to easily see the previews{% endraw %}{% else %}{% raw %}false{% endraw %}{% endif %}{% raw %}{% endraw %}

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -18,3 +18,4 @@ aws_region_for_stack: us-east-2
 # Data added based on the specifics of this template
 has_backend: true
 frontend_deployed_port_number: 3000
+create_internal_docker_compose_network: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -23,3 +23,4 @@ aws_region_for_stack: us-west-1
 # Data added based on the specifics of this template
 has_backend: false
 frontend_deployed_port_number: 8000
+create_internal_docker_compose_network: false


### PR DESCRIPTION
 ## Why is this change necessary?
Sometimes containers need to access things on the local intranet


 ## How does this change address the issue?
Adds a question to make it optional


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Some initial searching didn't seem to reveal a way with docker or docker compose to make it possible to block internet access from containers but still allow access to local PCs :shrug: