### PR TITLE
Resolve docker E2E CI issue

### DIFF
--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -6,14 +6,15 @@
     "type-check": "vue-tsc --noEmit",
     "lint": "eslint . --fix --ext .vue,.ts,.js",
     "build": "pnpm run type-check && nuxt build",
-    "dev": "nuxt dev",
+    "comment-about-dev-no-fork": "sometimes it seems needed, other times it seems to work with it...more info https://github.com/nuxt/cli/issues/181",
+    "dev": "nuxt dev --no-fork",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare && pnpm exec playwright-core install --only-shell chromium-headless-shell",
     "test-unit": "vitest --dir tests/unit run --coverage",
     "test-unit:watch": "vitest --dir tests/unit",
     "test-e2e": "vitest --dir tests/e2e run",
-    "test-e2e:docker": "USE_DOCKER_COMPOSE_FOR_VITEST_E2E=1 vitest --dir tests/e2e run",
+    "test-e2e:docker": "docker compose --file=../docker-compose.yaml build && USE_DOCKER_COMPOSE_FOR_VITEST_E2E=1 vitest --dir tests/e2e run",
     "test-e2e:watch": "vitest --dir tests/e2e"
   },
   "dependencies": {

--- a/template/frontend/tests/e2e/index.spec.ts
+++ b/template/frontend/tests/e2e/index.spec.ts
@@ -15,7 +15,7 @@ describe("Index page", async () => {
       });
       await setup({ host: "http://localhost:3000" });
     }
-  }, 240 * 1000); // increase timeout in case image needs to be built
+  }, 40 * 1000); // increase timeout to allow docker compose to start
   afterAll(() => {
     if (process.env.USE_DOCKER_COMPOSE_FOR_VITEST_E2E) {
       console.log("Stopping docker-compose...");


### PR DESCRIPTION
 ## Why is this change necessary?
Docker builds were timing out in CI when running within vitest


 ## How does this change address the issue?
Builds the docker images prior to starting vitest


 ## What side effects does this change have?
None


 ## How is this change tested?
downstream repo


 ## Other
Adds the `--no-fork` flag that helped resolve some flakiness