### PR TITLE
Parametrize Ports

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.33-4-g8c82740
+_commit: v0.0.34
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.33-3-g8a2168e
+_commit: v0.0.33-4-g8c82740
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.33
+_commit: v0.0.33-3-g8a2168e
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -59,5 +59,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): cf054ee0 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 042b6789 # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -13,8 +13,8 @@ curl -LsSf https://astral.sh/uv/0.6.17/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 
-# Ensure that uv won't use the default system Python
-default_version="3.12.7"
+# Set to the system version of Python3 by default
+default_version=$(python3 -c "import sys; print ('.'.join((str(x) for x in sys.version_info[:3])))")
 
 # Use the input argument if provided, otherwise use the default value
 input="${1:-$default_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+### Added
+- Describe new features added in this version.
+
+### Changed
+- Describe changes in existing functionality.
+
+### Deprecated
+- List features that are still available but will be removed in future versions.
+
+### Removed
+- List features that have been removed.
+
+### Fixed
+- List any bug fixes.
+
+### Security
+- Describe security fixes or improvements.
+
+---
+
+## [0.1.0] - 2024-12-18
+
+### Added
+- Project setup.
+- Initial functionality implemented.
+
+---
+
+### How to Use This Changelog
+
+- **Added:** For new features.
+- **Changed:** For changes in existing functionality.
+- **Deprecated:** For features that will soon be removed.
+- **Removed:** For features that have been removed.
+- **Fixed:** For bug fixes.
+- **Security:** In case of vulnerabilities addressed.
+
+---
+
+### Versioning
+
+This project uses **Semantic Versioning (MAJOR.MINOR.PATCH)**:
+- **MAJOR:** Incompatible API changes.
+- **MINOR:** Backward-compatible new features.
+- **PATCH:** Backward-compatible bug fixes.
+
+For example:
+- `1.0.0`: Major release with breaking changes.
+- `1.1.0`: New backward-compatible feature.
+- `1.1.1`: Bug fix or minor change.
+
+---
+
+### Contributing to the Changelog
+
+When contributing changes, ensure you update the `[Unreleased]` section of this file with a brief description of your contribution.
+
+- Use clear, concise language.
+- Categorize your change under **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, or **Security**.
+
+When releasing a new version:
+1. Move changes from `[Unreleased]` to a new section with the version number and release date.
+2. Update any relevant documentation if necessary.
+
+---
+
+Thank you for helping us maintain a clean and clear changelog! 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [0.1.0] - 2024-12-18
 
 ### Added
-- Project setup.
 - Initial functionality implemented.
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@
 
 # Usage
 To create a new repository using this template:
-1. Install `copier` and `copier-templates-extensions`. An easy way to do that is to copy the `.devcontainer/install-ci-tooling.sh` script in this repository into your new repo and then run it.
-2. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-nuxt-python-intranet-app.git .`
-3. Run `uv lock` to generate the lock file
-4. Commit the changes
-5. Rebuild your new devcontainer
+1. Create a basic devcontainer either using the Codespaces default or using the file `.devcontainer/devcontainer-to-instantiate-template.json` from [the base template repo](https://github.com/LabAutomationAndScreening/copier-base-template/blob/main/.devcontainer/devcontainer-to-instantiate-template.json)
+1. Inside that devcontainer, run `sh .devcontainer/install-ci-tooling.sh` to install necessary tooling to instantiate the template (you can copy/paste the script from this
+1. Delete all files currently in the repository. Optional...but makes it easiest to avoid git conflicts.
+1. Run copier to instantiate the template: `copier copy --trust gh:LabAutomationAndScreening/copier-nuxt-python-intranet-app.git .`
+1. Run `uv lock` to generate the lock file
+1. Run `python3 .github/workflows/hash_git_files.py . --for-devcontainer-config-update` to update the hash for your devcontainer file
+1. Commit the changes (optional)
+1. Rebuild your new devcontainer
 
 
 

--- a/copier.yml
+++ b/copier.yml
@@ -86,10 +86,17 @@ has_backend:
     help: Does this project have a backend?
     default: yes
 
+backend_deployed_port_number:
+    type: int
+    help: What port should the backend be deployed to?
+    default: 4000
+    when: "{{ has_backend }}"
+
 backend_uses_graphql:
     type: bool
     help: Is the backend GraphQL?
     default: yes
+    when: "{{ has_backend }}"
 
 create_docker_image_tar_artifact:
     type: bool

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -38,6 +38,11 @@ class ContextUpdater(ContextHook):
         context["nuxt_ui_version"] = "^3.1.1"
         context["nuxt_version"] = "^3.17.2"
         context["typescript_version"] = "^5.8.2"
+        context["vue_version"] = "^3.5.13"
+        context["vue_router_version"] = "^4.5.0"
+        context["faker_version"] = "^9.7.0"
+        context["graphql_codegen_cli_version"] = "^5.0.5"
+        context["graphql_codegen_typescript_version"] = "^4.1.6"
 
         context["gha_checkout"] = "v4.2.2"
         context["gha_setup_python"] = "v5.5.0"

--- a/template/.devcontainer/install-ci-tooling.sh.jinja
+++ b/template/.devcontainer/install-ci-tooling.sh.jinja
@@ -18,8 +18,8 @@ curl -LsSf https://astral.sh/uv/{% endraw %}{{ uv_version }}{% raw %}/install.sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 
-# Ensure that uv won't use the default system Python
-default_version="{% endraw %}{{ python_version }}{% raw %}"
+# Set to the system version of Python3 by default
+default_version=$(python3 -c "import sys; print ('.'.join((str(x) for x in sys.version_info[:3])))")
 
 # Use the input argument if provided, otherwise use the default value
 input="${1:-$default_version}"

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+### Added
+- Describe new features added in this version.
+
+### Changed
+- Describe changes in existing functionality.
+
+### Deprecated
+- List features that are still available but will be removed in future versions.
+
+### Removed
+- List features that have been removed.
+
+### Fixed
+- List any bug fixes.
+
+### Security
+- Describe security fixes or improvements.
+
+---
+
+## [0.1.0] - 2024-12-18
+
+### Added
+- Project setup.
+- Initial functionality implemented.
+
+---
+
+### How to Use This Changelog
+
+- **Added:** For new features.
+- **Changed:** For changes in existing functionality.
+- **Deprecated:** For features that will soon be removed.
+- **Removed:** For features that have been removed.
+- **Fixed:** For bug fixes.
+- **Security:** In case of vulnerabilities addressed.
+
+---
+
+### Versioning
+
+This project uses **Semantic Versioning (MAJOR.MINOR.PATCH)**:
+- **MAJOR:** Incompatible API changes.
+- **MINOR:** Backward-compatible new features.
+- **PATCH:** Backward-compatible bug fixes.
+
+For example:
+- `1.0.0`: Major release with breaking changes.
+- `1.1.0`: New backward-compatible feature.
+- `1.1.1`: Bug fix or minor change.
+
+---
+
+### Contributing to the Changelog
+
+When contributing changes, ensure you update the `[Unreleased]` section of this file with a brief description of your contribution.
+
+- Use clear, concise language.
+- Categorize your change under **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, or **Security**.
+
+When releasing a new version:
+1. Move changes from `[Unreleased]` to a new section with the version number and release date.
+2. Update any relevant documentation if necessary.
+
+---
+
+Thank you for helping us maintain a clean and clear changelog! 🚀

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -10,7 +10,7 @@
 
 # Development
 
-To spin up the docker stack (frontend accessible on port 3000):
+To spin up the docker stack (frontend accessible on port {% endraw %}{{ frontend_deployed_port_number }}{% raw %}{% endraw %}{% if has_backend %}{% raw %}, backend accessible on port {% endraw %}{{ backend_deployed_port_number }}{% endif %}{% raw %}), run:
 ```bash
 docker compose up
 ```

--- a/template/deployment/docker-compose.yaml.jinja
+++ b/template/deployment/docker-compose.yaml.jinja
@@ -3,7 +3,7 @@
     image: 183631337349.dkr.ecr.us-east-1.amazonaws.com/{% endraw %}{{ repo_name }}{% raw %}-backend:latest
     container_name: {% endraw %}{{ repo_name }}{% raw %}-backend
     ports:
-      - "4000:4000" # TODO: figure out why the deployed server is ignoring the envvar to set the URL, so that we can change this to `expose: 4000` to only make the backend available within the docker network, don't risk conflicts with a port on the host machine
+      - "{% endraw %}{{ backend_deployed_port_number }}{% raw %}:4000"
     pull_policy: never  # Prevents Docker from pulling the image
     restart: unless-stopped
     networks:

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -5,7 +5,7 @@
       dockerfile: Dockerfile
     container_name: {% endraw %}{{ repo_name }}{% raw %}-backend
     ports:
-      - "4000:4000"
+      - "{% endraw %}{{ backend_deployed_port_number }}{% raw %}:4000"
     restart: unless-stopped
     networks:
       - internal_net

--- a/template/docker-compose.yaml.jinja
+++ b/template/docker-compose.yaml.jinja
@@ -16,7 +16,7 @@
       dockerfile: Dockerfile
     container_name: {% endraw %}{{ repo_name }}{% raw %}-frontend
     ports:
-      - "3000:3000"{% endraw %}{% if has_backend %}{% raw %}
+      - "{% endraw %}{{ frontend_deployed_port_number }}{% raw %}:3000"{% endraw %}{% if has_backend %}{% raw %}
     depends_on:
       - backend{% endraw %}{% endif %}{% raw %}
     environment:

--- a/template/frontend/Dockerfile.jinja
+++ b/template/frontend/Dockerfile.jinja
@@ -2,7 +2,7 @@
 FROM node:{% endraw %}{{ node_version }}{% raw %}-alpine{% endraw %}{{ alpine_image_version }}{% raw %} AS builder
 
 # docker build -t my-nuxt-app .
-# docker run -p 3000:3000 my-nuxt-app
+# docker run -p {% endraw %}{{ frontend_deployed_port_number }}{% raw %}:3000 my-nuxt-app
 
 # Install pnpm globally
 RUN npm install -g pnpm@{% endraw %}{{ pnpm_version }}{% raw %}

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -23,7 +23,7 @@
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "typescript": "{% endraw %}{{ typescript_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
-    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}",
+    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"
   },
   "devDependencies": {
     "@faker-js/faker": "{% endraw %}{{ faker_version }}{% raw %}",{% endraw %}{% if frontend_uses_graphql %}{% raw %}

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -22,13 +22,13 @@
     "@nuxt/ui": "{% endraw %}{{ nuxt_ui_version }}{% raw %}",
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "typescript": "{% endraw %}{{ typescript_version }}{% raw %}",
-    "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue": "{% endraw %}{{ vue_version }}{% raw %}",
+    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}",
   },
   "devDependencies": {
-    "@faker-js/faker": "^9.7.0",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
-    "@graphql-codegen/cli": "^5.0.5",
-    "@graphql-codegen/typescript": "^4.1.6",
+    "@faker-js/faker": "{% endraw %}{{ faker_version }}{% raw %}",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
+    "@graphql-codegen/cli": "{% endraw %}{{ graphql_codegen_version }}{% raw %}",
+    "@graphql-codegen/typescript": "{% endraw %}{{ graphql_codegen_version }}{% raw %}",
     "@graphql-codegen/typescript-operations": "^4.6.0",
     "@graphql-codegen/typescript-vue-apollo": "^4.1.1",
     "@graphql-tools/mock": "^9.0.22",

--- a/template/frontend/tests/e2e/constants.ts.jinja
+++ b/template/frontend/tests/e2e/constants.ts.jinja
@@ -1,2 +1,1 @@
-{% raw %}/* eslint-disable @typescript-eslint/no-unused-vars */ // these are constants used in tests
-const DEPLOYED_FRONTEND_PORT_NUMBER = {% endraw %}{{ frontend_deployed_port_number }}{% raw %};{% endraw %}
+{% raw %}export const DEPLOYED_FRONTEND_PORT_NUMBER = {% endraw %}{{ frontend_deployed_port_number }}{% raw %};{% endraw %}

--- a/template/frontend/tests/e2e/constants.ts.jinja
+++ b/template/frontend/tests/e2e/constants.ts.jinja
@@ -1,0 +1,1 @@
+{% raw %}const DEPLOYED_FRONTEND_PORT_NUMBER = {% endraw %}{{ frontend_deployed_port_number }}{% raw %};{% endraw %}

--- a/template/frontend/tests/e2e/constants.ts.jinja
+++ b/template/frontend/tests/e2e/constants.ts.jinja
@@ -1,1 +1,2 @@
-{% raw %}const DEPLOYED_FRONTEND_PORT_NUMBER = {% endraw %}{{ frontend_deployed_port_number }}{% raw %};{% endraw %}
+{% raw %}/* eslint-disable @typescript-eslint/no-unused-vars */ // these are constants used in tests
+const DEPLOYED_FRONTEND_PORT_NUMBER = {% endraw %}{{ frontend_deployed_port_number }}{% raw %};{% endraw %}

--- a/template/frontend/tests/e2e/index.spec.ts
+++ b/template/frontend/tests/e2e/index.spec.ts
@@ -1,6 +1,7 @@
 import { createPage, setup, url } from "@nuxt/test-utils/e2e";
 import { execSync } from "child_process";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { DEPLOYED_FRONTEND_PORT_NUMBER } from "~/tests/e2e/constants";
 
 describe("Index page", async () => {
   if (!process.env.USE_DOCKER_COMPOSE_FOR_VITEST_E2E) {
@@ -13,7 +14,7 @@ describe("Index page", async () => {
       execSync("docker compose --file=../docker-compose.yaml up --detach --force-recreate --renew-anon-volumes", {
         stdio: "inherit",
       });
-      await setup({ host: "http://localhost:3000" });
+      await setup({ host: `http://localhost:${DEPLOYED_FRONTEND_PORT_NUMBER}` });
     }
   }, 40 * 1000); // increase timeout to allow docker compose to start
   afterAll(() => {

--- a/template/{% if has_backend %}backend{% endif %}/Dockerfile.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/Dockerfile.jinja
@@ -1,7 +1,7 @@
 {% raw %}FROM python:{% endraw %}{{ python_version }}{% raw %}-slim-{% endraw %}{{ debian_release_name }}{% raw %}
 
 # docker build -t my-graphql-backend .
-# docker run -p 4000:4000 my-graphql-backend
+# docker run -p {% endraw %}{{ backend_deployed_port_number }}{% raw %}:4000 my-graphql-backend
 
 # tell uv to treat /usr/local as the project env
 ENV UV_PROJECT_ENVIRONMENT=/usr/local

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -17,6 +17,7 @@ use_staging_environment: false
 aws_region_for_stack: us-east-2
 # Data added based on the specifics of this template
 has_backend: true
+backend_deployed_port_number: 8080
 backend_uses_graphql: true
 frontend_uses_graphql: true
 frontend_deployed_port_number: 3000

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -22,6 +22,7 @@ aws_development_account_id: 000321456870
 aws_region_for_stack: us-west-1
 # Data added based on the specifics of this template
 has_backend: false
+backend_deployed_port_number: 4001
 backend_uses_graphql: false
 frontend_uses_graphql: false
 frontend_deployed_port_number: 8000

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -17,6 +17,7 @@ use_staging_environment: false
 aws_region_for_stack: us-east-2
 # Data added based on the specifics of this template
 has_backend: true
+backend_deployed_port_number: 4000
 backend_uses_graphql: false
 frontend_uses_graphql: false
 frontend_deployed_port_number: 3000


### PR DESCRIPTION
 ## Why is this change necessary?
Need to be able to specify frontend and backend ports used during deployment, so we can avoid conflicts on a single server running multiple apps


 ## How does this change address the issue?
Adds question for that and updates docker compose and other files


 ## What side effects does this change have?
None


 ## How is this change tested?
Running docker compose and querying backend (and existing docker compose frontend test)


 ## Other
Pulled in some upstream updates with more context variables