### PR TITLE
Test coverage

### DIFF
--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -38,7 +38,7 @@
     "@nuxt/test-utils": "^3.17.2",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
     "@nuxtjs/apollo": "5.0.0-alpha.14",{% endraw %}{% endif %}{% raw %}
     "@nuxtjs/eslint-config-typescript": "^12.1.0",
-    "@vitest/coverage-v8": "^3.0.9",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
+    "@vitest/coverage-istanbul": "^3.1.3",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
     "@vue/apollo-composable": "^4.2.2",{% endraw %}{% endif %}{% raw %}
     "@vue/devtools-api": "^7.7.2",
     "@vue/test-utils": "^2.4.6",
@@ -54,7 +54,7 @@
     "playwright-core": "^1.51.1",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.0.14",
-    "vitest": "^3.0.9",
+    "vitest": "^3.1.3",
     "vue-eslint-parser": "^10.1.1",
     "vue-tsc": "^2.2.8"
   }

--- a/template/frontend/tests/unit/default-layout.nuxt.spec.ts
+++ b/template/frontend/tests/unit/default-layout.nuxt.spec.ts
@@ -1,0 +1,14 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, expect, test } from "vitest";
+
+import DefaultLayout from "~/layouts/default.vue";
+
+describe("default layout", () => {
+  test("component mounts without error", async () => {
+    expect.assertions(1);
+
+    const wrapper = await mountSuspended(DefaultLayout);
+
+    expect(wrapper.text()).toContain("Hello");
+  });
+});

--- a/template/frontend/vitest.config.ts
+++ b/template/frontend/vitest.config.ts
@@ -1,15 +1,24 @@
 import { defineVitestConfig } from "@nuxt/test-utils/config";
+import { coverageConfigDefaults } from "vitest/config";
+
+const fakerSeed = Number(process.env.TEST_FAKER_SEED) || Math.floor(Math.random() * 1e9); // to use this, you'll need to create a setup.ts file and add it to the vitest `setupFiles` config
 
 export default defineVitestConfig({
+  define: {
+    __TEST_FAKER_SEED__: JSON.stringify(fakerSeed),
+  },
   test: {
     sequence: {
       shuffle: true,
     },
     coverage: {
+      provider: "istanbul",
       reporter: ["text", "json", "html"],
       reportsDirectory: ".coverage",
-      skipFull: true,
-      ignoreEmptyLines: true,
+      thresholds: {
+        "100": true,
+      },
+      exclude: ["**/generated/graphql.ts", "**/codegen.ts", "**/nuxt.config.ts", ...coverageConfigDefaults.exclude],
     },
   },
 });


### PR DESCRIPTION
 ## Why is this change necessary?
Need to better support frontend test coverage


 ## How does this change address the issue?
Switches to istanbul provider since it better supports Vue SFCs. enables 100% coverage detection. excludes some not-real files from test coverage

Adds a test for the layout component


 ## What side effects does this change have?
Test coverage enforced


 ## How is this change tested?
two downstream repos
