### PR TITLE
Upload backend coverage report on failure

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -175,6 +175,9 @@ create_internal_docker_compose_network:
     default: no
     when: "{{ not deploy_as_executable }}"
 
+_skip_if_exists:
+    - backend/src/static/favicon.ico # TODO: figure out if there's another way to stop the template from overriding a changed icon
+
 # Additional Settings
 _min_copier_version: "9.4"
 

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -71,8 +71,7 @@ jobs:
         with:
           name: backend-test-coverage-${{ matrix.os }}
           path: backend/coverage-report-pytest
-          if-no-files-found: error
-        {% endraw %}{% endif %}{% raw %}
+          if-no-files-found: error{% endraw %}{% endif %}{% raw %}
 
   build-frontend:
     needs: [ lint, unit-test-frontend{% endraw %}{% if has_backend %}{% raw %}, unit-test-backend{% endraw %}{% endif %}{% raw %} ]

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -63,7 +63,16 @@ jobs:
           python-version: {% endraw %}{{ python_version }}{% raw %}
 
       - name: Unit test
-        run: uv --directory=backend run pytest tests/unit --cov-report=xml --durations=5{% endraw %}{% endif %}{% raw %}
+        run: uv --directory=backend run pytest tests/unit --durations=5
+
+      - name: Upload test coverage on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@{% endraw %}{{ gha_upload_artifact }}{% raw %}
+        with:
+          name: backend-test-coverage-${{ matrix.os }}
+          path: backend/coverage-report-pytest
+          if-no-files-found: error
+        {% endraw %}{% endif %}{% raw %}
 
   build-frontend:
     needs: [ lint, unit-test-frontend{% endraw %}{% if has_backend %}{% raw %}, unit-test-backend{% endraw %}{% endif %}{% raw %} ]

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -61,6 +61,7 @@ repos:
               .devcontainer/devcontainer-lock.json|
               .copier-answers.yml|
               .*\.xml|
+              .*/vendor_files/.*|
           )$
       - id: pretty-format-json
         exclude: |
@@ -120,6 +121,7 @@ repos:
         exclude: |
           (?x)^(
               .*/__snapshots__/.*|
+              .*/vendor_files/.*|
           )$
 
   # Invalid File Checks


### PR DESCRIPTION
 ## Why is this change necessary?
Trying to debug CI coverage failures


 ## How does this change address the issue?
Adds step to upload HTML coverage report if failure


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo


 ## Other
Ignoring changes to favicon and vendor files