### PR TITLE
Fix endpoint

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.49
+_commit: v0.0.53
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -64,9 +64,6 @@ def shutdown() -> ShutdownResponse:
     return ShutdownResponse()
 
 
-app.mount(
-    "/", StaticFiles(directory=STATIC_DIR, html=True), name="static"
-)  # this needs to go after any defined routes so that the routes take precedence
 try:
     app.add_middleware(
         CORSMiddleware,
@@ -77,6 +74,9 @@ try:
     ){% endraw %}{% if backend_uses_graphql %}{% raw %}
     graphql_app = GraphQLRouter(schema)
     app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}
+    app.mount(
+        "/", StaticFiles(directory=STATIC_DIR, html=True), name="static"
+    )  # this needs to go after any defined routes so that the routes take precedence
 except (  # pragma: no cover # This is just logging unexpected errors, and it's very challenging to explicitly unit test
     Exception
 ):

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/test_healthcheck.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/test_healthcheck.py.jinja
@@ -1,4 +1,4 @@
-import time
+{% raw %}import time
 
 from backend_api import app_def
 from backend_api.app_def import app
@@ -27,7 +27,16 @@ def test_When_swagger_route_called__Then_rendered():
     response = client.get("/api-docs")
 
     assert response.status_code == codes.OK
-    assert "Swagger UI" in response.text
+    assert "Swagger UI" in response.text{% endraw %}{% if backend_uses_graphql %}{% raw %}
+
+
+def test_When_graphql_route_called__Then_rendered():
+    client = TestClient(app)
+
+    response = client.get("/api/graphql")
+
+    assert response.status_code == codes.OK
+    assert "graphiql" in response.text{% endraw %}{% endif %}{% raw %}
 
 
 def test_When_shutdown_route_called__Then_system_exit(mocker: MockerFixture):
@@ -42,4 +51,4 @@ def test_When_shutdown_route_called__Then_system_exit(mocker: MockerFixture):
         if mocked_os_exit.call_count > 0:
             break
         time.sleep(0.001)
-    mocked_os_exit.assert_called_once_with(0)
+    mocked_os_exit.assert_called_once_with(0){% endraw %}


### PR DESCRIPTION
  ## Why is this change necessary?
The graphql endpoint was being obscured by the static file mount


 ## How does this change address the issue?
Rearranges the ordering of path definitions


 ## What side effects does this change have?
None


 ## How is this change tested?
unit test and live in downstream repo
