### PR TITLE
Fix: Only build backend in CI if there is a backend

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -115,7 +115,7 @@ jobs:
 
 {% endraw %}{% endif %}{% raw %}
 
-{% endraw %}{% if not deploy_as_executable %}{% raw %}
+{% endraw %}{% if has_backend %}{% raw %}{% endraw %}{% if not deploy_as_executable %}{% raw %}
   build-backend:
     needs: [ lint, unit-test-frontend, unit-test-backend ]
     uses: ./.github/workflows/build-docker-image.yaml
@@ -167,7 +167,7 @@ jobs:
         with:
           name: built-application-${{ matrix.os }}
           path: app.tar
-          if-no-files-found: error{% endraw %}{% endif %}{% raw %}
+          if-no-files-found: error{% endraw %}{% endif %}{% raw %}{% endraw %}{% endif %}{% raw %}
 
 
   test-compiled-frontend:


### PR DESCRIPTION
 ## Why is this change necessary?
In frontend-only repos, CI was failing


 ## How does this change address the issue?
Only attempts to run the build job if there is a backend


 ## What side effects does this change have?
N/A


 ## How is this change tested?
Downstream repos with and without a backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI now conditionally runs backend build and artifact upload only when a backend is enabled, avoiding unnecessary steps for frontend-only projects.
  - Balanced pipeline conditionals to ensure backend-related blocks are omitted when not applicable.
  - Reduces CI time and artifact clutter with no changes to frontend workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->