### PR TITLE
Fix conditional nitro pre-rendering for frontend-only

### DIFF
--- a/template/frontend/nuxt.config.ts.jinja
+++ b/template/frontend/nuxt.config.ts.jinja
@@ -31,12 +31,12 @@ export default defineNuxtConfig({
     },
   },
   css: ["~/assets/css/main.css"],
-  experimental: { appManifest: false }, // https://github.com/nuxt/nuxt/issues/30461#issuecomment-2572616714{% endraw %}{% if has_backend %}{% raw %}
+  experimental: { appManifest: false }, // https://github.com/nuxt/nuxt/issues/30461#issuecomment-2572616714
   nitro: {
     prerender: {
       concurrency: 1, // lower the concurrency to not be such a memory hog
       interval: 200, // ms pause between batches – lets the Garbage Collector catch up
-    },
+    },{% endraw %}{% if has_backend %}{% raw %}
     devProxy: {
       // this is just a proxy used for `pnpm dev`
       "/api": {
@@ -44,8 +44,8 @@ export default defineNuxtConfig({
         changeOrigin: true, // rewrite Host header
         prependPath: false, // keep /api prefix
       },
-    },
-  },{% endraw %}{% endif %}{% raw %}
+    },{% endraw %}{% endif %}{% raw %}
+  },
   vite: {
     server: {
       watch: {


### PR DESCRIPTION

 ## Why is this change necessary?
It wasn't being included in frontend-only repos


 ## How does this change address the issue?
Moves conditional


 ## What side effects does this change have?
None


 ## How is this change tested?
downstream frontend-only repo
