### PR TITLE
GraphQL Error Tracing

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -3,19 +3,14 @@ import os
 import threading
 import time
 from importlib.metadata import version
-from pathlib import Path{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from typing import override{% endraw %}{% endif %}{% raw %}
-{% endraw %}{% if backend_uses_graphql %}{% raw %}
-import strawberry{% endraw %}{% endif %}{% raw %}
-from fastapi import Query{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from fastapi import Request{% endraw %}{% endif %}{% raw %}
+from pathlib import Path
+
+from fastapi import Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi_offline import FastAPIOffline
 from pydantic import BaseModel
-from pydantic import Field{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from starlette.responses import HTMLResponse
-from strawberry.fastapi import GraphQLRouter{% endraw %}{% endif %}{% raw %}
+from pydantic import Field
 
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -19,7 +19,8 @@ from strawberry.fastapi import GraphQLRouter{% endraw %}{% endif %}{% raw %}
 
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from .schema_def import schema{% endraw %}{% endif %}{% raw %}
+from .schema_def import schema
+from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}
 
 logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).parent.parent
@@ -77,40 +78,7 @@ def shutdown() -> ShutdownResponse:
         )  # sys.exit just causes an internal server error, it doesn't actually stop the server. So a hard exit is needed
 
     threading.Thread(target=do_shutdown, name="execute_shutdown").start()
-    return ShutdownResponse(){% endraw %}{% if backend_uses_graphql %}{% raw %}
-
-
-class CdnUrlNotFoundInHtmlError(Exception):
-    def __init__(self, cdn_url: str):
-        super().__init__(f"CDN URL '{cdn_url}' not found in GraphiQL HTML.")
-
-
-def _get_graphiql_html_base() -> str:
-    # separate for mocking
-    return (Path(strawberry.__file__).with_name("static") / "graphiql.html").read_text()
-
-
-def generate_offline_graphiql_html() -> str:
-    offline_graphiql_html = _get_graphiql_html_base()
-    cdn_urls = [
-        "https://unpkg.com/react@18.2.0/umd/react.production.min.js",
-        "https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js",
-        "https://unpkg.com/js-cookie@3.0.5/dist/js.cookie.min.js",
-        "https://unpkg.com/graphiql@3.0.9/graphiql.min.css",
-        "https://unpkg.com/@graphiql/plugin-explorer@1.0.2/dist/style.css",
-        "https://unpkg.com/graphiql@3.0.9/graphiql.min.js",
-        "https://unpkg.com/@graphiql/plugin-explorer@1.0.2/dist/index.umd.js",
-    ]
-    for cdn_url in cdn_urls:
-        if cdn_url not in offline_graphiql_html:
-            raise CdnUrlNotFoundInHtmlError(cdn_url)
-        filename = cdn_url.split("/")[-1]
-        local_path = f"/static/graphiql/{filename}"
-        offline_graphiql_html = offline_graphiql_html.replace(cdn_url, local_path)
-    return "\n".join(
-        # checksums vary slightly after running pre-commit hooks on them locally, so remove the integrity check
-        [line for line in offline_graphiql_html.splitlines() if not line.startswith("      integrity=")]
-    ){% endraw %}{% endif %}{% raw %}
+    return ShutdownResponse()
 
 
 try:
@@ -121,12 +89,6 @@ try:
         allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
         allow_headers=["*"],
     ){% endraw %}{% if backend_uses_graphql %}{% raw %}
-    offline_graphiql_html = generate_offline_graphiql_html()
-
-    class OfflineGraphQLRouter(GraphQLRouter):
-        @override
-        async def render_graphql_ide(self, request: Request) -> HTMLResponse:
-            return HTMLResponse(offline_graphiql_html)
 
     graphql_app = OfflineGraphQLRouter(schema)
     app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}schema_def.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}schema_def.py{% endif %}
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import strawberry
 
+from .strawberry_router import AddErrorTrace
+
 logger = logging.getLogger(__name__)
 
-schema = strawberry.Schema(query=int)
+schema = strawberry.Schema(query=int, extensions=[AddErrorTrace()])
 sdl_path = Path(__file__).parent / "schema.graphql"
 _ = sdl_path.write_text(f"{schema.as_str()}\n")

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}strawberry_router.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}strawberry_router.py{% endif %}
@@ -1,0 +1,105 @@
+import logging
+from collections.abc import Iterator
+from pathlib import Path
+from typing import override
+
+import strawberry
+from fastapi import Request
+from graphql import GraphQLError
+from graphql.execution.execute import ExecutionResult
+from starlette.responses import HTMLResponse
+from strawberry.extensions.base_extension import SchemaExtension
+from strawberry.fastapi import GraphQLRouter
+from uuid_utils import uuid7
+
+logger = logging.getLogger(__name__)
+
+
+class AddErrorTrace(SchemaExtension):
+    # TODO: add envvar/config to determine whether to mask errors or not
+    # TODO: consider disabling the `strawberry.execution` logger since it seems to duplicate this functionality
+    def _process_result(self, result: ExecutionResult) -> None:
+        assert isinstance(result, ExecutionResult), f"Expected ExecutionResult, got {type(result)}"
+
+        if not result.errors:
+            return
+        for error in result.errors:
+            trace_id = str(uuid7())
+            error.message += f" (Error trace id: {trace_id})"
+            if error.extensions is None:
+                error.extensions = {}  # pragma: no cover # not sure how to create a test that triggers this, but it seems good practice to handle the case where the existing extensions should be None
+            error.extensions["traceId"] = trace_id
+            is_client_error = error.path is None
+            if is_client_error:
+                logger.warning(f"GraphQL input error [urn:uuid:{trace_id}]: {error.message}")
+            else:
+                starting_phrase = "Execution contract"
+                if error.original_error is not None and not isinstance(error.original_error, GraphQLError):
+                    if not (  # most schema contract errors show up as GraphQL errors with no original error, but some do have original errors
+                        isinstance(error.original_error, TypeError)
+                        and str(error.original_error).startswith("Cannot return null for non-nullable field")
+                    ):
+                        starting_phrase = "Unhandled"
+                logger.error(
+                    f"{starting_phrase} error within GraphQL resolver at path {error.path} [urn:uuid:{trace_id}]",
+                    exc_info=error.original_error,
+                )
+
+    @override
+    def on_operation(self) -> Iterator[None]:
+        yield
+        result = self.execution_context.result  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType] # yes, it's unknown, that's why we're asserting to confirm
+        assert isinstance(result, (ExecutionResult, type(None))), (
+            f"Expected ExecutionResult or None, got {type(result)}"  # pyright: ignore[reportUnknownArgumentType] # yes, it's unknown, that's why we're asserting to confirm
+        )
+        if result is None:
+            return  # pragma: no cover # not sure how to create a test that triggers this, but it seems good practice to gracefully handle the case where this is None
+
+        self._process_result(result)
+
+
+class CdnUrlNotFoundInHtmlError(Exception):
+    def __init__(self, cdn_url: str):
+        super().__init__(f"CDN URL '{cdn_url}' not found in GraphiQL HTML.")
+
+
+def _get_graphiql_html_base() -> str:
+    # separate for mocking
+    return (Path(strawberry.__file__).with_name("static") / "graphiql.html").read_text()
+
+
+def generate_offline_graphiql_html() -> str:
+    offline_graphiql_html = _get_graphiql_html_base()
+    cdn_urls = [
+        "https://unpkg.com/react@18.2.0/umd/react.production.min.js",
+        "https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js",
+        "https://unpkg.com/js-cookie@3.0.5/dist/js.cookie.min.js",
+        "https://unpkg.com/graphiql@3.8.3/graphiql.min.css",
+        "https://unpkg.com/@graphiql/plugin-explorer@1.0.2/dist/style.css",
+        "https://unpkg.com/graphiql@3.8.3/graphiql.min.js",
+        "https://unpkg.com/@graphiql/plugin-explorer@1.0.2/dist/index.umd.js",
+    ]
+    for cdn_url in cdn_urls:
+        if cdn_url not in offline_graphiql_html:
+            raise CdnUrlNotFoundInHtmlError(cdn_url)
+        filename = cdn_url.split("/")[-1]
+        local_path = f"/static/graphiql/{filename}"
+        offline_graphiql_html = offline_graphiql_html.replace(cdn_url, local_path)
+    return "\n".join(
+        # checksums vary slightly after running pre-commit hooks on them locally, so remove the integrity check
+        [line for line in offline_graphiql_html.splitlines() if not line.startswith("      integrity=")]
+    )
+
+
+try:
+    offline_graphiql_html = generate_offline_graphiql_html()
+
+    class OfflineGraphQLRouter(GraphQLRouter):
+        @override
+        async def render_graphql_ide(self, request: Request) -> HTMLResponse:
+            return HTMLResponse(offline_graphiql_html)
+except (  # pragma: no cover # This is just logging unexpected errors, and it's very challenging to explicitly unit test
+    Exception
+):
+    logger.exception("Unhandled error")
+    raise

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_graphiql.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_graphiql.py{% endif %}
@@ -1,7 +1,7 @@
 import pytest
-from backend_api import app_def
-from backend_api.app_def import CdnUrlNotFoundInHtmlError
+from backend_api import strawberry_router
 from backend_api.app_def import app
+from backend_api.strawberry_router import CdnUrlNotFoundInHtmlError
 from fastapi.testclient import TestClient
 from httpx import codes
 from pytest_mock import MockerFixture
@@ -9,13 +9,13 @@ from pytest_mock import MockerFixture
 
 def test_When_expected_cdn_not_found_in_graphiql_html__Then_error(mocker: MockerFixture):
     _ = mocker.patch.object(
-        app_def,
-        app_def._get_graphiql_html_base.__name__,  # noqa: SLF001 # yes, this is private, but we need to mock the internals in order to test the main functionality
+        strawberry_router,
+        strawberry_router._get_graphiql_html_base.__name__,  # noqa: SLF001 # yes, this is private, but we need to mock the internals in order to test the main functionality
         autospec=True,
         return_value="blah",
     )
     with pytest.raises(CdnUrlNotFoundInHtmlError, match="react.production.min.js"):
-        _ = app_def.generate_offline_graphiql_html()
+        _ = strawberry_router.generate_offline_graphiql_html()
 
 
 def test_When_graphql_route_called__Then_rendered():

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_strawberry_exception_handler.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_strawberry_exception_handler.py{% endif %}
@@ -1,0 +1,242 @@
+import random
+from uuid import uuid4
+
+import pytest
+import strawberry
+from backend_api import fast_api_exception_handlers
+from backend_api import strawberry_router
+from backend_api.strawberry_router import AddErrorTrace
+from pytest_mock import MockerFixture
+from uuid_utils import uuid7
+
+RETURNED_UUIDS = [uuid7() for _ in range(5)]
+
+
+def _run_logic(value: str) -> str:
+    return value
+
+
+def _run_other_logic(value: int) -> int:
+    return value
+
+
+@strawberry.type
+class Query:
+    @strawberry.field
+    def do_something(self, value: str) -> str:
+        return _run_logic(value)
+
+    @strawberry.field
+    def do_other_thing(self, value: int) -> int:
+        return _run_other_logic(value)
+
+
+schema = strawberry.Schema(query=Query, extensions=[AddErrorTrace()])
+
+GQL = """query ($value: String!) {
+                doSomething(value: $value)
+            }
+            """
+
+GQL_BOTH = """query ($value1: String!, $value2: Int!) {
+                doSomething(value: $value1)
+                doOtherThing(value: $value2)
+            }
+            """
+
+
+class Helper:
+    mocker: MockerFixture
+
+    def _mock_should_show_error_details(self, *, should_show: bool):
+        _ = self.mocker.patch.object(
+            fast_api_exception_handlers,
+            fast_api_exception_handlers.should_show_error_details.__name__,
+            autospec=True,
+            return_value=should_show,
+        )
+
+
+class TestSingleError(Helper):
+    @pytest.fixture(autouse=True)
+    def _setup(self, mocker: MockerFixture):
+        self.mocker = mocker
+        self.spied_logger_error = mocker.spy(strawberry_router.logger, "error")
+        self.spied_uuid_generator = mocker.spy(strawberry_router, "uuid7")
+        self.spied_logger_warning = mocker.spy(strawberry_router.logger, "warning")
+
+    def test_Given_resolver_internal_mocked_to_error_and_error_details_should_be_displayed__Then_uuid_in_log_and_response__and_details_in_response_and_log(
+        self,
+    ):
+        self._mock_should_show_error_details(should_show=True)
+        expected_error_message = str(uuid4())
+        error_cls = random.choice(
+            (ValueError, RuntimeError, KeyError, TypeError)
+        )  # arbitrary list of a variety of error types
+        expected_error = error_cls(expected_error_message)
+
+        _ = self.mocker.patch(f"{__name__}.{_run_logic.__name__}", autospec=True, side_effect=expected_error)
+
+        result = schema.execute_sync(
+            GQL_BOTH,
+            variable_values={"value1": str(uuid4()), "value2": random.randint(1, 100)},
+        )
+
+        self.spied_uuid_generator.assert_called_once()
+        expected_uuid = str(self.spied_uuid_generator.spy_return)
+
+        assert result.errors is not None
+        assert len(result.errors) == 1
+        error = result.errors[0]
+        assert expected_uuid in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == expected_uuid
+        self.spied_logger_error.assert_called_once()
+        log_call_args = self.spied_logger_error.call_args[0]
+        log_call_kwargs = self.spied_logger_error.call_args[1]
+        log_message = log_call_args[0]
+        logged_error = log_call_kwargs["exc_info"]
+        assert expected_uuid in log_message
+        assert "doSomething" in log_message
+        assert log_message.startswith("Unhandled") is True
+        assert logged_error == expected_error
+
+    def test_Given_resolver_returns_wrong_type_for_second_query_and_error_details_should_not_be_displayed__Then_uuid_in_log_and_response__and_details_in_response_and_log_because_this_isnt_sensitive(
+        self,
+    ):
+        self._mock_should_show_error_details(should_show=False)
+        wrong_value_1 = str(uuid4())
+        _ = self.mocker.patch(f"{__name__}.{_run_other_logic.__name__}", autospec=True, return_value=wrong_value_1)
+
+        result = schema.execute_sync(
+            GQL_BOTH,
+            variable_values={"value1": str(uuid4()), "value2": random.randint(1, 100)},
+        )
+
+        assert result.errors is not None
+        assert len(result.errors) == 1
+        self.spied_uuid_generator.assert_called_once()
+        assert self.spied_logger_error.call_count == 1
+        expected_uuid = str(self.spied_uuid_generator.spy_return)
+
+        error = result.errors[0]
+        assert expected_uuid in error.message
+        assert wrong_value_1 in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == expected_uuid
+        log_call_args = self.spied_logger_error.call_args[0]
+        log_message = log_call_args[0]
+        assert expected_uuid in log_message
+        assert "doOtherThing" in log_message
+        assert log_message.startswith("Execution contract") is True
+
+    def test_Given_resolver_returns_null_value_for_second_query_not_matching_schema_and_error_details_should_not_be_displayed__Then_uuid_in_log_and_response__and_details_in_response_and_log_because_this_isnt_sensitive(
+        self,
+    ):
+        self._mock_should_show_error_details(should_show=False)
+        wrong_value_1 = None
+        _ = self.mocker.patch(f"{__name__}.{_run_other_logic.__name__}", autospec=True, return_value=wrong_value_1)
+
+        result = schema.execute_sync(
+            GQL_BOTH,
+            variable_values={"value1": str(uuid4()), "value2": random.randint(1, 100)},
+        )
+
+        assert result.errors is not None
+        assert len(result.errors) == 1
+        self.spied_uuid_generator.assert_called_once()
+        assert self.spied_logger_error.call_count == 1
+        expected_uuid = str(self.spied_uuid_generator.spy_return)
+
+        error = result.errors[0]
+        assert expected_uuid in error.message
+        assert "doOtherThing" in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == expected_uuid
+        log_call_args = self.spied_logger_error.call_args[0]
+        log_message = log_call_args[0]
+        assert expected_uuid in log_message
+        assert "doOtherThing" in log_message
+        assert log_message.startswith("Execution contract") is True
+
+    def test_Given_invalid_input_for_second_query_and_error_details_should_not_be_displayed__Then_uuid_in_log_and_response__and_details_in_response_and_log_because_this_isnt_sensitive(
+        self,
+    ):
+        self._mock_should_show_error_details(should_show=False)
+        wrong_value_2 = random.choice([True, False])
+
+        result = schema.execute_sync(
+            GQL_BOTH,
+            variable_values={"value1": str(uuid4()), "value2": wrong_value_2},
+        )
+
+        assert result.errors is not None
+        assert len(result.errors) == 1
+        self.spied_uuid_generator.assert_called_once()
+        assert self.spied_logger_warning.call_count == 1
+        expected_uuid = str(self.spied_uuid_generator.spy_return)
+
+        error = result.errors[0]
+        assert expected_uuid in error.message
+        assert "$value2" in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == expected_uuid
+        log_call_args = self.spied_logger_warning.call_args[0]
+        log_message = log_call_args[0]
+        assert expected_uuid in log_message
+        assert "$value2" in log_message
+
+
+class TestExceptionHandlersForMultipleErrors(Helper):
+    @pytest.fixture(autouse=True)
+    def _setup(self, mocker: MockerFixture):
+        self.mocker = mocker
+        self.spied_logger_error = mocker.spy(strawberry_router.logger, "error")
+        self.mocked_uuid_generator = mocker.patch.object(
+            strawberry_router, "uuid7", autospec=True, side_effect=RETURNED_UUIDS
+        )
+        self.spied_logger_warning = mocker.spy(strawberry_router.logger, "warning")
+
+    def test_Given_invalid_input_for_both_queries_and_error_details_should_not_be_displayed__Then_uuid_in_log_and_response__and_details_in_response_and_log_because_this_isnt_sensitive(
+        self,
+    ):
+        self._mock_should_show_error_details(should_show=False)
+        wrong_value_1 = random.randint(1, 100)
+        wrong_value_2 = random.choice([True, False])
+        expected_num_errors = 2
+
+        result = schema.execute_sync(
+            GQL_BOTH,
+            variable_values={"value1": wrong_value_1, "value2": wrong_value_2},
+        )
+
+        assert result.errors is not None
+        assert len(result.errors) == expected_num_errors
+        assert self.mocked_uuid_generator.call_count == expected_num_errors
+        assert self.spied_logger_warning.call_count == expected_num_errors
+
+        error = result.errors[0]
+        assert str(RETURNED_UUIDS[0]) in error.message
+        assert "$value1" in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == str(RETURNED_UUIDS[0])
+        log_call_args = self.spied_logger_warning.call_args_list[0][0]
+        log_message = log_call_args[0]
+        assert str(RETURNED_UUIDS[0]) in log_message
+        assert "$value1" in log_message
+
+        error = result.errors[1]
+        assert str(RETURNED_UUIDS[1]) in error.message
+        assert "$value2" in error.message
+        assert isinstance(error.extensions, dict)
+        assert "traceId" in error.extensions
+        assert error.extensions["traceId"] == str(RETURNED_UUIDS[1])
+        log_call_args = self.spied_logger_warning.call_args_list[1][0]
+        log_message = log_call_args[0]
+        assert str(RETURNED_UUIDS[1]) in log_message
+        assert "$value2" in log_message


### PR DESCRIPTION
 ## Why is this change necessary?
Add UUIDs to error messages and logs for GraphQL errors


 ## How does this change address the issue?
Creates a Strawberry Extension that adds UUIDs to error messages and also to the extensions key in the error object.


 ## What side effects does this change have?
None


 ## How is this change tested?
Unit and live in downstream repos with and without GraphQL


 ## Other
Refactored much of the GraphQL stuff in app_def.py into strawberry_router.py so that there's not as much complex Jinja logic in the template

For now it does not redact any error details in the response to the client---this ability will be implemented later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline GraphQL IDE: GraphiQL now works without internet access by serving local assets, improving reliability in restricted environments.
  - Enhanced GraphQL error observability: each error includes a trace ID in responses, aiding support and debugging; improved logging for both client and server errors.

- Tests
  - Added comprehensive tests for offline GraphiQL generation and error tracing across single and multiple error scenarios to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->