### PR TITLE
Random port for backend when testing build executable

### DIFF
--- a/template/frontend/tests/setup/globalSetup.ts
+++ b/template/frontend/tests/setup/globalSetup.ts
@@ -30,7 +30,7 @@ function getRandomOpenPort(): Promise<number> {
     });
   });
 }
-const availablePort = await getRandomOpenPort();
+const availablePort = await getRandomOpenPort(); // TODO: consider moving this into the setup and then updating the BASE_URL and heathcheckURL afterwards. unlikely but possible situation where the port gets taken before setup is invoked
 const isE2E = process.env.USE_DOCKER_COMPOSE_FOR_VITEST_E2E || process.env.USE_BUILT_BACKEND_FOR_VITEST_E2E;
 const isDockerE2E = process.env.USE_DOCKER_COMPOSE_FOR_VITEST_E2E;
 const isBuiltBackendE2E = process.env.USE_BUILT_BACKEND_FOR_VITEST_E2E;


### PR DESCRIPTION
 ## Why is this change necessary?
Flaky in CI using a specific port


 ## How does this change address the issue?
Randomizes the port number


 ## What side effects does this change have?
We're not testing _exactly_ the port we plan to deploy on in CI, but the deployed port can vary at the installation site anyway...it's a CLI argument


 ## How is this change tested?
Downstream repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * E2E test setup now uses dynamic port allocation instead of hardcoded ports, reducing conflicts and improving test reliability.
  * Built-backend startup and health checks now operate on the dynamically assigned port.
  * Non-built-backend and docker-compose E2E flows remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->