### PR TITLE
Bump gcc

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/{% if not deploy_as_executable %}Dockerfile{% endif %}.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/{% if not deploy_as_executable %}Dockerfile{% endif %}.jinja
@@ -14,7 +14,7 @@ RUN uv --version
 
 RUN apt-get update && apt-get install -y \
     --no-install-recommends \{% endraw %}{% if install_gcc_in_backend_container_build_phase %}{% raw %}
-    "gcc=$(apt-cache madison gcc | awk '{print $3}' | grep '4:12\.2\.' | head -n 1)" \{% endraw %}{% endif %}{% raw %}
+    "gcc=$(apt-cache madison gcc | awk '{print $3}' | grep '4:14\.2\.' | head -n 1)" \{% endraw %}{% endif %}{% raw %}
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
`trixie` doesn't contain the old version of gcc, so need to use a newer one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the compiler version used in backend builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->