### PR TITLE
Fix: starter schema

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/__snapshots__/test_basic_server_functionality/test_openapi_schema.json.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/__snapshots__/test_basic_server_functionality/test_openapi_schema.json.jinja
@@ -174,6 +174,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Why is this change necessary?
The new fastapi makes a slightly different schema format


## How does this change address the issue?
Updates the default starter so brand new templates don't have to regenerate one


## What side effects does this change have?
N/A


## How is this change tested?
The applied changes came from doing this in a brand new repo.  but I didn't want to completely E2E test creating a new repo from scratch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Validation error responses now include additional context and input information, providing clearer and more actionable feedback when API validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->