### PR TITLE
More host_mode cleanup in docker-compose

### DIFF
--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -9,7 +9,7 @@
     "build": "nuxt build",
     "comment-about-dev-no-fork": "sometimes it seems needed, other times it seems to work with it...more info https://github.com/nuxt/cli/issues/181",
     "dev": "nuxt dev --no-fork",{% endraw %}{% if has_backend %}{% raw %}
-    "openapi-codegen": "mkdir -p ./app/generated/open-api/backend && docker run --network host --user $(id -u):$(id -g) -v ./app/generated/open-api/backend:/app/output -v $PWD/../backend/tests/unit/__snapshots__/test_basic_server_functionality/test_openapi_schema.json:/app/openapi.json mcr.microsoft.com/openapi/kiota:{% endraw %}{{ kiota_cli_version }}{% raw %} generate -l typescript -c BackendClient -n client -d openapi.json --exclude-backward-compatible --clean-output --additional-data false && python3 ./kiota_nullable_fixer.py",{% endraw %}{% endif %}{% raw %}
+    "openapi-codegen": "mkdir -p ./app/generated/open-api/backend && docker run --user $(id -u):$(id -g) -v ./app/generated/open-api/backend:/app/output -v $PWD/../backend/tests/unit/__snapshots__/test_basic_server_functionality/test_openapi_schema.json:/app/openapi.json mcr.microsoft.com/openapi/kiota:{% endraw %}{{ kiota_cli_version }}{% raw %} generate -l typescript -c BackendClient -n client -d openapi.json --exclude-backward-compatible --clean-output --additional-data false && python3 ./kiota_nullable_fixer.py",{% endraw %}{% endif %}{% raw %}
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "node ./scripts/postinstall.mjs",

--- a/template/{% if not deploy_as_executable %}docker-compose.yaml{% endif %}.jinja
+++ b/template/{% if not deploy_as_executable %}docker-compose.yaml{% endif %}.jinja
@@ -26,9 +26,7 @@ services:{% endraw %}{% if has_backend %}{% raw %}
     depends_on:
       - backend{% endraw %}{% endif %}{% raw %}
     environment:
-      BACKEND_HOST: host.docker.internal
+      BACKEND_HOST: backend
       BACKEND_PORT: {% endraw %}{{ backend_deployed_port_number }}{% raw %}
       FRONTEND_PORT: {% endraw %}{{ frontend_deployed_port_number }}{% raw %}
-    restart: unless-stopped
-    extra_hosts:
-      - "host.docker.internal:host-gateway"{% endraw %}
+    restart: unless-stopped{% endraw %}


### PR DESCRIPTION
## Why is this change necessary?
we can just use docker internal networking for simplicity everywhere now (including the frontend)


## How does this change address the issue?
Updates docker compose


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo


## Other
Don't need network mode for Kiota when it's reading a file from disk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build and Compose configurations to streamline backend service connectivity within containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->