### PR TITLE
More kiota fixer

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-9-g48fbfcc
+_commit: v0.0.115-10-g43cd2f7
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-8-ga00672e
+_commit: v0.0.115-9-g48fbfcc
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-10-g43cd2f7
+_commit: v0.0.116
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-2-gb6dce06
+_commit: v0.0.115-3-g5b86075
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-7-g51bfdc9
+_commit: v0.0.115-8-ga00672e
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115
+_commit: v0.0.115-2-gb6dce06
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-5-ged787b4
+_commit: v0.0.115-6-g219b32b
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-3-g5b86075
+_commit: v0.0.115-4-ga124d4c
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-6-g219b32b
+_commit: v0.0.115-7-g51bfdc9
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.115-4-ga124d4c
+_commit: v0.0.115-5-ged787b4
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
       "extensions": [
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.4",
+        "coderabbit.coderabbit-vscode@0.18.5",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): f72edd75 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): af51de02 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): af51de02 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): c69bde03 # spellchecker:disable-line
 }

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -69,10 +69,15 @@ def _normalize_json(body: str) -> str:
         return body
 
 
-def _make_logging_body_matcher() -> Callable[[_VCRRequest, _VCRRequest], None]:
+def _make_logging_body_matcher(
+    *normalizers: Callable[[str], str],
+) -> Callable[[_VCRRequest, _VCRRequest], None]:
     def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
         b1 = _normalize_json(_decode_vcr_body(r1.body))
         b2 = _normalize_json(_decode_vcr_body(r2.body))
+        for normalize in normalizers:
+            b1 = normalize(b1)
+            b2 = normalize(b2)
         if b1 != b2:
             diff = "\n".join(
                 difflib.unified_diff(

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -52,19 +52,23 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
         _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
     except AssertionError as err:
-        b1 = _read_body_as_str(r1)
-        b2 = _read_body_as_str(r2)
-        diff = "\n".join(
-            difflib.unified_diff(
-                b2.splitlines(),
-                b1.splitlines(),
-                fromfile="cassette",
-                tofile="actual",
-                lineterm="",
+        try:
+            b1 = _read_body_as_str(r1)
+            b2 = _read_body_as_str(r2)
+            diff = "\n".join(
+                difflib.unified_diff(
+                    b2.splitlines(),
+                    b1.splitlines(),
+                    fromfile="cassette",
+                    tofile="actual",
+                    lineterm="",
+                )
             )
-        )
-        logger.info(f"VCR body mismatch:\n{diff}")
-        print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+            logger.info(f"VCR body mismatch:\n{diff}")
+            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+        except Exception:
+            logger.exception("Error while logging VCR body mismatch")
+            raise AssertionError from err
         raise AssertionError(
             f"Request body mismatch:\n{diff}"
         ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -1,6 +1,7 @@
 import difflib
 import logging
 import os
+import traceback
 from typing import Any
 from typing import cast
 
@@ -52,6 +53,11 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
         _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
     except AssertionError as err:
+        tb_frames = traceback.extract_tb(err.__traceback__)
+        if (
+            not tb_frames or f"{os.sep}vcr{os.sep}" not in tb_frames[-1].filename
+        ):  # if the assertion error came from something else in pytest, just rethrow it. Only log the diff if the assertion error came from within VCRpy itself
+            raise
         try:
             b1 = _read_body_as_str(r1)
             b2 = _read_body_as_str(r2)
@@ -64,14 +70,11 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
                     lineterm="",
                 )
             )
-            logger.info(f"VCR body mismatch:\n{diff}")
-            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
         except Exception:
             logger.exception("Error while logging VCR body mismatch")
             raise AssertionError from err
-        raise AssertionError(
-            f"Request body mismatch:\n{diff}"
-        ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
+        # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
+        raise AssertionError(f"Request body mismatch:\n{diff}") from err
 
 
 def pytest_recording_configure(

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -1,4 +1,5 @@
 import difflib
+import json
 import logging
 import os
 from collections.abc import Callable
@@ -61,15 +62,17 @@ class _VCRRequest:
     body: object
 
 
-def _make_logging_body_matcher(
-    *normalizers: Callable[[str], str],
-) -> Callable[[_VCRRequest, _VCRRequest], None]:
+def _normalize_json(body: str) -> str:
+    try:
+        return json.dumps(json.loads(body), sort_keys=True)
+    except (ValueError, TypeError):
+        return body
+
+
+def _make_logging_body_matcher() -> Callable[[_VCRRequest, _VCRRequest], None]:
     def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
-        b1 = _decode_vcr_body(r1.body)
-        b2 = _decode_vcr_body(r2.body)
-        for normalize in normalizers:
-            b1 = normalize(b1)
-            b2 = normalize(b2)
+        b1 = _normalize_json(_decode_vcr_body(r1.body))
+        b2 = _normalize_json(_decode_vcr_body(r2.body))
         if b1 != b2:
             diff = "\n".join(
                 difflib.unified_diff(

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -47,7 +47,7 @@ def _decode_vcr_body(body: object) -> str:
     if isinstance(body, str):
         return body
     if isinstance(body, BytesIO):
-        return body.read().decode("utf-8")
+        return body.getvalue().decode("utf-8")
     if isinstance(body, Iterator):
         raise NotImplementedError(
             "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -1,9 +1,17 @@
+import difflib
+import logging
 import os
+import re
+from collections.abc import Callable
+from collections.abc import Iterator
+from io import BytesIO
 from typing import Any
 from typing import cast
 
 import pytest
 from vcr import VCR
+
+logger = logging.getLogger(__name__)
 
 UNREACHABLE_IP_ADDRESS = "192.0.2.1"  # RFC 5737 TEST-NET-1
 IGNORED_HOSTS = [
@@ -32,6 +40,48 @@ def vcr_config() -> dict[str, list[str]]:
     return cfg
 
 
+def _decode_vcr_body(body: object) -> str:
+    if body is None:
+        return ""
+    if isinstance(body, bytes):
+        return body.decode("utf-8")
+    if isinstance(body, str):
+        return body
+    if isinstance(body, BytesIO):
+        return body.read().decode("utf-8")
+    if isinstance(body, Iterator):
+        raise NotImplementedError(
+            "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."
+        )
+    raise TypeError(f"Unexpected VCR body type: {type(body)}")
+
+
+def _make_logging_body_matcher(
+    *normalizers: Callable[[str], str],
+) -> Callable[["_VCRRequest", "_VCRRequest"], None]:
+    def _body_matcher(r1: "_VCRRequest", r2: "_VCRRequest") -> None:
+        b1 = _decode_vcr_body(r1.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+        b2 = _decode_vcr_body(r2.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+        for normalize in normalizers:
+            b1 = normalize(b1)
+            b2 = normalize(b2)
+        if b1 != b2:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    b2.splitlines(),
+                    b1.splitlines(),
+                    fromfile="cassette",
+                    tofile="actual",
+                    lineterm="",
+                )
+            )
+            logger.warning("VCR body mismatch:\n%s", diff)
+            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+            raise AssertionError(f"Request body mismatch:\n{diff}")
+
+    return _body_matcher
+
+
 def pytest_recording_configure(
     config: pytest.Config,  # noqa: ARG001 # the config argument MUST be present (even when unused) or pytest-recording throws an error
     vcr: VCR,
@@ -40,7 +90,9 @@ def pytest_recording_configure(
     assert isinstance(vcr.match_on, tuple), (
         f"vcr.match_on is not a tuple, it is a {type(vcr.match_on)} with value {vcr.match_on}"
     )
-    vcr.match_on += ("body",)  # body is not included by default, but it seems relevant
+
+    vcr.register_matcher("logging_body", _make_logging_body_matcher())  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
+    vcr.match_on += ("logging_body",)  # body is not included by default, but it seems relevant
 
     def before_record_response(response: dict[str, str | dict[str, Any]]) -> dict[str, str | dict[str, Any]]:
         headers_to_filter = (
@@ -62,3 +114,9 @@ def pytest_recording_configure(
         return response
 
     vcr.before_record_response = before_record_response
+
+
+class _VCRRequest:
+    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
+
+    body: object

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -1,15 +1,14 @@
 import difflib
-import json
 import logging
 import os
-from collections.abc import Callable
-from collections.abc import Iterator
-from io import BytesIO
 from typing import Any
 from typing import cast
 
 import pytest
 from vcr import VCR
+from vcr import matchers as _vcr_matchers
+from vcr.request import Request as VCRRequest
+from vcr.util import read_body as _vcr_read_body  # pyright: ignore[reportUnknownVariableType] # vcrpy is untyped
 
 logger = logging.getLogger(__name__)
 
@@ -40,59 +39,35 @@ def vcr_config() -> dict[str, list[str]]:
     return cfg
 
 
-def _decode_vcr_body(body: object) -> str:
-    if body is None:
+def _read_body_as_str(request: VCRRequest) -> str:
+    raw = _vcr_read_body(request)  # pyright: ignore[reportUnknownVariableType] # vcrpy is untyped
+    if raw is None:
         return ""
-    if isinstance(body, bytes):
-        return body.decode("utf-8")
-    if isinstance(body, str):
-        return body
-    if isinstance(body, BytesIO):
-        return body.getvalue().decode("utf-8")
-    if isinstance(body, Iterator):
-        raise NotImplementedError(
-            "VCR body is an Iterator — element type is ambiguous (bytes chunks vs ints). Extend _decode_vcr_body if you need to support streaming request bodies."
-        )
-    raise TypeError(f"Unexpected VCR body type: {type(body)}")
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8")
+    return str(raw)  # pyright: ignore[reportUnknownArgumentType] # vcrpy is untyped
 
 
-class _VCRRequest:
-    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
-
-    body: object
-
-
-def _normalize_json(body: str) -> str:
+def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
     try:
-        return json.dumps(json.loads(body), sort_keys=True)
-    except (ValueError, TypeError):
-        return body
-
-
-def _make_logging_body_matcher(
-    *normalizers: Callable[[str], str],
-) -> Callable[[_VCRRequest, _VCRRequest], None]:
-    def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
-        b1 = _normalize_json(_decode_vcr_body(r1.body))
-        b2 = _normalize_json(_decode_vcr_body(r2.body))
-        for normalize in normalizers:
-            b1 = normalize(b1)
-            b2 = normalize(b2)
-        if b1 != b2:
-            diff = "\n".join(
-                difflib.unified_diff(
-                    b2.splitlines(),
-                    b1.splitlines(),
-                    fromfile="cassette",
-                    tofile="actual",
-                    lineterm="",
-                )
+        _vcr_matchers.body(r1, r2)  # pyright: ignore[reportUnknownMemberType] # vcrpy is untyped
+    except AssertionError as err:
+        b1 = _read_body_as_str(r1)
+        b2 = _read_body_as_str(r2)
+        diff = "\n".join(
+            difflib.unified_diff(
+                b2.splitlines(),
+                b1.splitlines(),
+                fromfile="cassette",
+                tofile="actual",
+                lineterm="",
             )
-            logger.warning("VCR body mismatch:\n%s", diff)
-            print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
-            raise AssertionError(f"Request body mismatch:\n{diff}")
-
-    return _body_matcher
+        )
+        logger.info(f"VCR body mismatch:\n{diff}")
+        print(f"\nVCR body mismatch:\n{diff}")  # noqa: T201 # intentional debug output to surface cassette drift
+        raise AssertionError(
+            f"Request body mismatch:\n{diff}"
+        ) from err  # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
 
 
 def pytest_recording_configure(
@@ -104,7 +79,7 @@ def pytest_recording_configure(
         f"vcr.match_on is not a tuple, it is a {type(vcr.match_on)} with value {vcr.match_on}"
     )
 
-    vcr.register_matcher("logging_body", _make_logging_body_matcher())  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
+    vcr.register_matcher("logging_body", _logging_body_matcher)  # pyright: ignore[reportUnknownMemberType] # vcrpy is not fully typed
     vcr.match_on += ("logging_body",)  # body is not included by default, but it seems relevant
 
     def before_record_response(response: dict[str, str | dict[str, Any]]) -> dict[str, str | dict[str, Any]]:

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -72,7 +72,7 @@ def _logging_body_matcher(r1: VCRRequest, r2: VCRRequest) -> None:
             )
         except Exception:
             logger.exception("Error while logging VCR body mismatch")
-            raise AssertionError from err
+            raise err from None  # if there's some failure generating the diff, just raise the original error unchanged
         # TODO: figure out why Body is the only VCRpy matcher that doesn't include an error message of the diff, and see about creating an issue in VCRpy repo itself
         raise AssertionError(f"Request body mismatch:\n{diff}") from err
 

--- a/copier_template_resources/vcrpy_fixtures.py
+++ b/copier_template_resources/vcrpy_fixtures.py
@@ -1,7 +1,6 @@
 import difflib
 import logging
 import os
-import re
 from collections.abc import Callable
 from collections.abc import Iterator
 from io import BytesIO
@@ -56,12 +55,18 @@ def _decode_vcr_body(body: object) -> str:
     raise TypeError(f"Unexpected VCR body type: {type(body)}")
 
 
+class _VCRRequest:
+    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
+
+    body: object
+
+
 def _make_logging_body_matcher(
     *normalizers: Callable[[str], str],
-) -> Callable[["_VCRRequest", "_VCRRequest"], None]:
-    def _body_matcher(r1: "_VCRRequest", r2: "_VCRRequest") -> None:
-        b1 = _decode_vcr_body(r1.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
-        b2 = _decode_vcr_body(r2.body)  # pyright: ignore[reportUnknownMemberType, reportUnknownArgumentType] # vcrpy body property is untyped
+) -> Callable[[_VCRRequest, _VCRRequest], None]:
+    def _body_matcher(r1: _VCRRequest, r2: _VCRRequest) -> None:
+        b1 = _decode_vcr_body(r1.body)
+        b2 = _decode_vcr_body(r2.body)
         for normalize in normalizers:
             b1 = normalize(b1)
             b2 = normalize(b2)
@@ -114,9 +119,3 @@ def pytest_recording_configure(
         return response
 
     vcr.before_record_response = before_record_response
-
-
-class _VCRRequest:
-    """Structural stub for type-checking vcr.request.Request — vcrpy ships no type stubs."""
-
-    body: object

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -13,7 +13,7 @@ class ContextUpdater(ContextHook):
         context["uv_version"] = "0.11.7"
         context["pnpm_version"] = "10.33.1"
         context["pre_commit_version"] = "4.5.1"
-        context["pyright_version"] = ">=1.1.408"
+        context["pyright_version"] = ">=1.1.409"
         context["pytest_version"] = ">=9.0.3"
         context["pytest_randomly_version"] = ">=4.1.0"
         context["pytest_cov_version"] = ">=7.1.0"
@@ -35,7 +35,7 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = ">=0.298.0"
         context["fastapi_version"] = ">=0.135.3"
         context["fastapi_offline_version"] = ">=1.7.4"
-        context["uvicorn_version"] = ">=0.44.0"
+        context["uvicorn_version"] = ">=0.46.0"
         context["lab_auto_pulumi_version"] = ">=0.2.0"
         context["ariadne_codegen_version"] = ">=0.18.0"
         context["pytest_mock_version"] = ">=3.15.1"
@@ -112,7 +112,7 @@ class ContextUpdater(ContextHook):
         context["alpine_image_version"] = "3.23"
         context["nginx_image_version"] = "1.29.4"
 
-        context["kiota_cli_version"] = "1.31.0"
+        context["kiota_cli_version"] = "1.31.1"
 
         context["py312_version"] = "3.12.7"
         context["py313_version"] = "3.13.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
-    "pyright[nodejs]>=1.1.408",
+    "pyright[nodejs]>=1.1.409",
     "ty>=0.0.32",
     "copier==9.14.3",
     "copier-template-extensions==0.3.3"

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -41,7 +41,7 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code{% endraw %}{% endif %}{% raw %}
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.18.4",
+        "coderabbit.coderabbit-vscode@0.18.5",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
         "github.copilot@1.388.0",

--- a/template/frontend/kiota_nullable_fixer.py
+++ b/template/frontend/kiota_nullable_fixer.py
@@ -450,6 +450,7 @@ def get_models_with_primitive_array_fields(schema: dict[str, Any]) -> dict[str, 
                 continue
 
             field_type = field_schema.get("type")
+            field_format = field_schema.get("format")
 
             if field_type == "array":
                 items = field_schema.get("items", {})
@@ -475,6 +476,8 @@ def get_models_with_primitive_array_fields(schema: dict[str, Any]) -> dict[str, 
                         "writeCollectionOfPrimitiveValues<boolean>",
                     )
                     has_primitive_array = True
+            elif field_type == "string" and field_format == "date-time":
+                field_specs[field_name] = ("Date", "getDateValue()", "writeDateValue")
             elif field_type == "string":
                 field_specs[field_name] = ("string", "getStringValue()", "writeStringValue")
             elif field_type in ("integer", "number"):

--- a/template/frontend/kiota_nullable_fixer.py
+++ b/template/frontend/kiota_nullable_fixer.py
@@ -40,7 +40,7 @@ def load_openapi_schema(source: str) -> dict[str, Any]:
             print(f"Error fetching OpenAPI schema from {source}: {e}")
             sys.exit(1)
     else:
-        # pylint: disable=duplicate-code # this is shared with the fixer script for typescript code
+        # pylint: disable=duplicate-code # this is shared with the fixer script for python code
         # Treat as file path
         file_path = Path(source)
         if not file_path.exists():
@@ -585,7 +585,7 @@ def main(schema: dict[str, Any] | None = None):
     if anyof_fixes > 0:
         print(f"✓ Fixed {anyof_fixes} types with anyOf nullable issues")
 
-    # pylint: disable=duplicate-code # this is shared with the fixer script for typescript code
+    # pylint: disable=duplicate-code # this is shared with the fixer script for python code
     # Fix 3: Inject fields Kiota dropped due to primitive array types
     models_with_array_fields = get_models_with_primitive_array_fields(schema)
     if not models_with_array_fields:

--- a/template/frontend/kiota_nullable_fixer.py
+++ b/template/frontend/kiota_nullable_fixer.py
@@ -449,8 +449,8 @@ def get_models_with_primitive_array_fields(schema: dict[str, Any]) -> dict[str, 
             if "anyOf" in field_schema or "$ref" in field_schema:
                 continue
 
-            field_type = field_schema.get("type")
             field_format = field_schema.get("format")
+            field_type = field_schema.get("type")
 
             if field_type == "array":
                 items = field_schema.get("items", {})

--- a/template/frontend/kiota_nullable_fixer.py
+++ b/template/frontend/kiota_nullable_fixer.py
@@ -432,6 +432,122 @@ def fix_anyof_nullable_types(file_path: Path) -> int:
     return 0
 
 
+def get_models_with_primitive_array_fields(schema: dict[str, Any]) -> dict[str, dict[str, tuple[str, str, str]]]:
+    """Find models whose fields Kiota silently drops due to primitive array types.
+
+    Returns: dict mapping model_name -> {field_name: (ts_type, getter_call, writer_method)}
+    """
+    result: dict[str, dict[str, tuple[str, str, str]]] = {}
+    schemas = schema.get("components", {}).get("schemas", {})
+
+    for model_name, model_schema in schemas.items():
+        properties = model_schema.get("properties", {})
+        has_primitive_array = False
+        field_specs: dict[str, tuple[str, str, str]] = {}
+
+        for field_name, field_schema in properties.items():
+            if "anyOf" in field_schema or "$ref" in field_schema:
+                continue
+
+            field_type = field_schema.get("type")
+
+            if field_type == "array":
+                items = field_schema.get("items", {})
+                item_type = items.get("type")
+                if item_type == "string":
+                    field_specs[field_name] = (
+                        "string[]",
+                        "getCollectionOfPrimitiveValues<string>()",
+                        "writeCollectionOfPrimitiveValues<string>",
+                    )
+                    has_primitive_array = True
+                elif item_type in ("integer", "number"):
+                    field_specs[field_name] = (
+                        "number[]",
+                        "getCollectionOfPrimitiveValues<number>()",
+                        "writeCollectionOfPrimitiveValues<number>",
+                    )
+                    has_primitive_array = True
+                elif item_type == "boolean":
+                    field_specs[field_name] = (
+                        "boolean[]",
+                        "getCollectionOfPrimitiveValues<boolean>()",
+                        "writeCollectionOfPrimitiveValues<boolean>",
+                    )
+                    has_primitive_array = True
+            elif field_type == "string":
+                field_specs[field_name] = ("string", "getStringValue()", "writeStringValue")
+            elif field_type in ("integer", "number"):
+                field_specs[field_name] = ("number", "getNumberValue()", "writeNumberValue")
+            elif field_type == "boolean":
+                field_specs[field_name] = ("boolean", "getBooleanValue()", "writeBooleanValue")
+
+        if has_primitive_array and field_specs:
+            result[model_name] = field_specs
+
+    return result
+
+
+def inject_missing_typescript_fields(content: str, model_name: str, fields: dict[str, tuple[str, str, str]]) -> str:
+    """Inject fields that Kiota dropped from a TypeScript model due to the primitive array bug.
+
+    Kiota issue: https://github.com/microsoft/kiota/issues/4054
+    """
+    var_name = model_name[0].lower() + model_name[1:]
+
+    interface_props: list[str] = []
+    deser_entries: list[str] = []
+    serializer_calls: list[str] = []
+
+    deser_func_name = f"deserializeInto{model_name}"
+    deser_func_idx = content.find(f"function {deser_func_name}")
+
+    for field_name, (ts_type, getter, writer) in fields.items():
+        camel_field = re.sub(r"_([a-z])", lambda m: m.group(1).upper(), field_name)
+
+        # Skip if field already present in this model's deserializer
+        if deser_func_idx != -1:
+            deser_end = content.find("\n}\n", deser_func_idx)
+            if f'"{field_name}"' in content[deser_func_idx : deser_end + 3]:
+                continue
+
+        interface_props.append(f" {camel_field}?: {ts_type} | null;")
+        deser_entries.append(f' "{field_name}": n => {{ {var_name}.{camel_field} = n.{getter}; }},')
+        serializer_calls.append(f' writer.{writer}("{field_name}", {var_name}.{camel_field});')
+
+    if not interface_props:
+        return content
+
+    # Inject interface properties into empty interface
+    empty_interface = f"export interface {model_name} extends Parsable {{\n}}"
+    if empty_interface in content:
+        filled_interface = f"export interface {model_name} extends Parsable {{\n" + "\n".join(interface_props) + "\n}"
+        content = content.replace(empty_interface, filled_interface, 1)
+
+    # Inject deserializer entries into empty return dict
+    empty_return = " return {\n }"
+    if deser_func_idx != -1:
+        return_idx = content.find(empty_return, deser_func_idx)
+        func_end = content.find("\n}\n", deser_func_idx)
+        if return_idx != -1 and return_idx < func_end:
+            filled_return = " return {\n" + "\n".join(deser_entries) + "\n }"
+            content = content[:return_idx] + filled_return + content[return_idx + len(empty_return) :]
+
+    # Inject serializer calls after the early-return guard
+    serialize_func_name = f"serialize{model_name}"
+    serialize_func_idx = content.find(f"function {serialize_func_name}")
+    if serialize_func_idx != -1:
+        early_return = "{ return; }\n}"
+        early_idx = content.find(early_return, serialize_func_idx)
+        func_end = content.find("\n}\n", serialize_func_idx)
+        if early_idx != -1 and early_idx < func_end + 3:
+            filled_body = "{ return; }\n" + "\n".join(serializer_calls) + "\n}"
+            content = content[:early_idx] + filled_body + content[early_idx + len(early_return) :]
+
+    print(f"  Injected missing fields into {model_name}: {', '.join(fields.keys())}")
+    return content
+
+
 def main(schema: dict[str, Any] | None = None):
     """Main function to fix TypeScript models.
 
@@ -468,6 +584,19 @@ def main(schema: dict[str, Any] | None = None):
     anyof_fixes = fix_anyof_nullable_types(index_file)
     if anyof_fixes > 0:
         print(f"✓ Fixed {anyof_fixes} types with anyOf nullable issues")
+
+    # pylint: disable=duplicate-code # this is shared with the fixer script for typescript code
+    # Fix 3: Inject fields Kiota dropped due to primitive array types
+    models_with_array_fields = get_models_with_primitive_array_fields(schema)
+    if not models_with_array_fields:
+        print("\nNo models with primitive array fields found")
+    else:
+        print(f"\nFound {len(models_with_array_fields)} models with primitive array fields to inject")
+        content = index_file.read_text()
+        for model_name, fields in models_with_array_fields.items():
+            content = inject_missing_typescript_fields(content, model_name, fields)
+        _ = index_file.write_text(content)
+    # pylint: enable=duplicate-code
 
 
 if __name__ == "__main__":

--- a/template/{% if has_backend %}backend{% endif %}/kiota_nullable_fixer.py
+++ b/template/{% if has_backend %}backend{% endif %}/kiota_nullable_fixer.py
@@ -224,6 +224,148 @@ def fix_model_file(file_path: Path, model_name: str, fields: dict[str, str]) -> 
     return False
 
 
+def get_models_with_primitive_array_fields(schema: dict[str, Any]) -> dict[str, dict[str, str]]:
+    """Find models whose fields Kiota silently drops due to primitive array types.
+
+    Kiota drops ALL fields from a model when any field has a direct (non-anyOf) primitive array
+    type. This function identifies those models and returns ALL their simple (non-$ref) fields so
+    they can be injected back into the generated output.
+
+    Returns: dict mapping model_name -> {field_name: python_type}
+    """
+    result: dict[str, dict[str, str]] = {}
+    schemas = schema.get("components", {}).get("schemas", {})
+
+    for model_name, model_schema in schemas.items():
+        properties = model_schema.get("properties", {})
+        has_primitive_array = False
+        field_types: dict[str, str] = {}
+
+        for field_name, field_schema in properties.items():
+            if "anyOf" in field_schema or "$ref" in field_schema:
+                continue
+
+            field_type = field_schema.get("type")
+            field_format = field_schema.get("format")
+
+            if field_type == "array":
+                items = field_schema.get("items", {})
+                item_type = items.get("type")
+                if item_type == "string":
+                    field_types[field_name] = "list[str]"
+                    has_primitive_array = True
+                elif item_type == "integer":
+                    field_types[field_name] = "list[int]"
+                    has_primitive_array = True
+                elif item_type == "number":
+                    field_types[field_name] = "list[float]"
+                    has_primitive_array = True
+                elif item_type == "boolean":
+                    field_types[field_name] = "list[bool]"
+                    has_primitive_array = True
+            elif field_type == "string" and field_format == "date-time":
+                field_types[field_name] = "datetime"
+            elif field_type == "string":
+                field_types[field_name] = "str"
+            elif field_type == "integer":
+                field_types[field_name] = "int"
+            elif field_type == "number":
+                field_types[field_name] = "float"
+            elif field_type == "boolean":
+                field_types[field_name] = "bool"
+
+        if has_primitive_array and field_types:
+            result[model_name] = field_types
+
+    return result
+
+
+def inject_missing_python_fields(file_path: Path, model_name: str, fields: dict[str, str]) -> bool:
+    """Inject fields that Kiota dropped from a Python model due to the primitive array bug.
+
+    Kiota issue: https://github.com/microsoft/kiota/issues/4054
+    """
+    content = file_path.read_text()
+    original_content = content
+    needs_datetime_import = False
+
+    field_declarations: list[str] = []
+    deser_entries: list[str] = []
+    serializer_calls: list[str] = []
+
+    for field_name, field_type in fields.items():
+        field_snake = humps.decamelize(field_name)
+
+        if f'"{field_name}"' in content:
+            continue
+
+        if field_type == "str":
+            getter = "get_str_value()"
+            writer_call = f'writer.write_str_value("{field_name}", self.{field_snake})'
+            python_type = "str"
+        elif field_type == "bool":
+            getter = "get_bool_value()"
+            writer_call = f'writer.write_bool_value("{field_name}", self.{field_snake})'
+            python_type = "bool"
+        elif field_type == "int":
+            getter = "get_int_value()"
+            writer_call = f'writer.write_int_value("{field_name}", self.{field_snake})'
+            python_type = "int"
+        elif field_type == "float":
+            getter = "get_float_value()"
+            writer_call = f'writer.write_float_value("{field_name}", self.{field_snake})'
+            python_type = "float"
+        elif field_type == "datetime":
+            getter = "get_datetime_value()"
+            writer_call = f'writer.write_datetime_value("{field_name}", self.{field_snake})'
+            python_type = "datetime.datetime"
+            needs_datetime_import = True
+        elif field_type.startswith("list["):
+            inner = field_type[5:-1]
+            getter = f"get_collection_of_primitive_values({inner})"
+            writer_call = f'writer.write_collection_of_primitive_values("{field_name}", self.{field_snake})'
+            python_type = field_type
+        else:
+            continue
+
+        field_declarations.append(f"    {field_snake}: Optional[{python_type}] = None")
+        deser_entries.append(f"            \"{field_name}\": lambda n : setattr(self, '{field_snake}', n.{getter}),")
+        serializer_calls.append(f"        {writer_call}")
+
+    if not field_declarations:
+        return False
+
+    decl_block = "\n".join(field_declarations) + "\n"
+    content = content.replace(
+        "    @staticmethod\n    def create_from_discriminator_value",
+        f"{decl_block}    @staticmethod\n    def create_from_discriminator_value",
+        1,
+    )
+
+    deser_block = "\n".join(deser_entries) + "\n        "
+    content = content.replace(
+        "        fields: dict[str, Callable[[Any], None]] = {\n        }",
+        f"        fields: dict[str, Callable[[Any], None]] = {{\n{deser_block}}}",
+        1,
+    )
+
+    serializer_block = "\n".join(serializer_calls) + "\n"
+    content = content.replace(
+        '            raise TypeError("writer cannot be null.")\n    \n',
+        f'            raise TypeError("writer cannot be null.")\n{serializer_block}    \n',
+        1,
+    )
+
+    if needs_datetime_import and "import datetime" not in content:
+        content = re.sub(r"(from __future__ import annotations\n)", r"\1import datetime\n", content)
+
+    if content != original_content:
+        _ = file_path.write_text(content)
+        print(f"  Injected missing fields into {model_name}: {', '.join(fields.keys())}")
+        return True
+    return False
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fix Kiota's incorrect nullable handling in generated Python models")
     _ = parser.add_argument(
@@ -252,37 +394,49 @@ def main() -> None:
     schema = load_openapi_schema(args.openapi_source)
     # pylint: enable=duplicate-code
 
-    # Find fields to fix
-    simple_nullable_fields = get_anyof_simple_nullable_fields(schema)
-
-    if not simple_nullable_fields:
-        print("No anyOf [simple_type, null] fields found in OpenAPI schema")
-        return
-
-    print(f"Found {len(simple_nullable_fields)} models with anyOf [simple_type, null] fields")
-
     fixed_models = 0
     removed_files = 0
 
-    for model_name, fields in simple_nullable_fields.items():
-        field_list = [f"{k}:{v}" for k, v in fields.items()]
-        print(f"\nProcessing {model_name}: {', '.join(field_list)}")
+    # Fix 1: anyOf [simple_type, null] fields
+    simple_nullable_fields = get_anyof_simple_nullable_fields(schema)
+    if not simple_nullable_fields:
+        print("No anyOf [simple_type, null] fields found in OpenAPI schema")
+    else:
+        print(f"Found {len(simple_nullable_fields)} models with anyOf [simple_type, null] fields")
+        for model_name, fields in simple_nullable_fields.items():
+            field_list = [f"{k}:{v}" for k, v in fields.items()]
+            print(f"\nProcessing {model_name}: {', '.join(field_list)}")
 
-        # Fix the main model file (convert PascalCase to snake_case)
-        model_file = models_dir / f"{humps.decamelize(model_name)}.py"
-        if model_file.exists():
-            if fix_model_file(model_file, model_name, fields):
-                fixed_models += 1
-        else:
-            print(f"  Warning: Model file not found: {model_file}")
+            model_file = models_dir / f"{humps.decamelize(model_name)}.py"
+            if model_file.exists():
+                if fix_model_file(model_file, model_name, fields):
+                    fixed_models += 1
+            else:
+                print(f"  Warning: Model file not found: {model_file}")
 
-        # Remove composed type files
-        for field in fields.keys():
-            # Convert field name from camelCase to snake_case for the file name
-            field_snake = humps.decamelize(field)
-            composed_type_file = models_dir / f"{humps.decamelize(model_name)}_{field_snake}.py"
-            if fix_composed_type_file(composed_type_file):
-                removed_files += 1
+            for field in fields.keys():
+                field_snake = humps.decamelize(field)
+                composed_type_file = models_dir / f"{humps.decamelize(model_name)}_{field_snake}.py"
+                if fix_composed_type_file(composed_type_file):
+                    removed_files += 1
+
+    # pylint: disable=duplicate-code # this is shared with the fixer script for typescript code
+    # Fix 2: Inject fields Kiota dropped due to primitive array types
+    models_with_array_fields = get_models_with_primitive_array_fields(schema)
+    if not models_with_array_fields:
+        print("\nNo models with primitive array fields found")
+    else:
+        print(f"\nFound {len(models_with_array_fields)} models with primitive array fields to inject")
+        for model_name, fields in models_with_array_fields.items():
+            field_list = [f"{k}:{v}" for k, v in fields.items()]
+            print(f"\nInjecting into {model_name}: {', '.join(field_list)}")
+            model_file = models_dir / f"{humps.decamelize(model_name)}.py"
+            if model_file.exists():
+                if inject_missing_python_fields(model_file, model_name, fields):
+                    fixed_models += 1
+            else:
+                print(f"  Warning: Model file not found: {model_file}")
+    # pylint: enable=duplicate-code
 
     print(f"\n✓ Fixed {fixed_models} model files")
     print(f"✓ Removed {removed_files} composed type files")

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = "==9.14.3" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.408" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -387,15 +387,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Why is this change necessary?
Kiota still struggles sometimes with lists of primitives (e.g. `list[float]`)


## How does this change address the issue?
Updates the fixer scripts for Codegen for Python and Typescript to handle it


## What side effects does this change have?
N/A


## How is this change tested?
Several downstream repos

## Other
Updated vcrpy helper to print out the diff when the body matcher fails, for easier troubleshooting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code generation now correctly includes primitive-array fields in generated backend and frontend models.

* **Tests**
  * Improved test diagnostics for request-body mismatches to show clearer diffs on failure.

* **Chores**
  * Updated development container configuration, template reference, and minimum tooling version constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->