### PR TITLE
Add in info in app_def.py for circuit python backend

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -122,14 +122,14 @@ human_friendly_app_name:
 backend_makes_api_calls:
     type: bool
     help: Will the backend make calls to an external API?
-    default: no
-    when: "{{ has_backend }}"
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ has_backend and not is_circuit_python_driver }}"
 
 backend_source_uses_kiota:
     type: bool
     help: Will the backend make calls to an external API using Kiota-generated client code?
-    default: no
-    when: "{{ has_backend and backend_makes_api_calls }}"
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ has_backend and backend_makes_api_calls and not is_circuit_python_driver }}"
 
 backend_deployed_port_number:
     type: int
@@ -140,14 +140,14 @@ backend_deployed_port_number:
 backend_uses_graphql:
     type: bool
     help: Is the backend GraphQL?
-    default: yes
-    when: "{{ has_backend }}"
+    default: "{{ not is_circuit_python_driver }}"
+    when: "{{ has_backend and not is_circuit_python_driver }}"
 
 deploy_as_executable:
     type: bool
     help: Should this application be deployed as a single standalone executable?
     default: no
-    when: "{{ has_backend }}"
+    when: "{{ has_backend and not is_circuit_python_driver }}"
 
 install_gcc_in_backend_container_build_phase:
     type: bool
@@ -223,8 +223,8 @@ auth_to_ecr_for_e2e_in_ci_role_arn:
 run_backend_e2e_in_ci:
     type: bool
     help: Should a separate job in CI be created to run E2E tests just against the backend (Note - this does not actually work for executables yet, still TODO)?
-    default: false
-    when: "{{ has_backend }}"
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ has_backend and not is_circuit_python_driver }}"
 
 auth_to_ecr_for_backend_e2e_in_ci:
     type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -10,6 +10,12 @@ is_circuit_python_driver:
     default: no
     when: "{{ has_backend }}"
 
+has_circuit_python_backend_template_been_instantiated:
+    type: bool
+    help: Has the CircuitPython backend template been instantiated in this repository yet?
+    default: no
+    when: "{{ is_circuit_python_driver }}"
+
 
 
 # Questions managed by upstream template

--- a/copier.yml
+++ b/copier.yml
@@ -65,11 +65,13 @@ install_aws_ssm_port_forwarding_plugin:
 configure_vcrpy:
     type: bool
     help: Should VCRpy be configured for use during unit testing in Python?
-    default: no
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ not is_circuit_python_driver }}"
 configure_python_asyncio:
     type: bool
     help: Will Python code be using asyncio?
-    default: no
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ not is_circuit_python_driver }}"
 
 python_version:
     type: str

--- a/copier.yml
+++ b/copier.yml
@@ -153,8 +153,8 @@ is_circuit_python_driver:
 install_gcc_in_backend_container_build_phase:
     type: bool
     help: Is GCC required to build any Python dependencies in the backend container?
-    default: no
-    when: "{{ not deploy_as_executable and has_backend }}"
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ not deploy_as_executable and has_backend and not is_circuit_python_driver }}"
 
 create_docker_image_tar_artifact:
     type: bool

--- a/copier.yml
+++ b/copier.yml
@@ -1,6 +1,14 @@
 # Questions specific to this template
+has_backend:
+    type: bool
+    help: Does this project have a backend?
+    default: yes
 
-
+is_circuit_python_driver:
+    type: bool
+    help: Is this backend a CircuitPython device driver?
+    default: no
+    when: "{{ has_backend }}"
 
 
 
@@ -109,11 +117,6 @@ human_friendly_app_name:
     help: What's the human-friendly name of this application? (e.g. for documentation)
     default: "{{ repo_name.replace('-', ' ').replace('_', ' ') }}"
 
-has_backend:
-    type: bool
-    help: Does this project have a backend?
-    default: yes
-
 backend_makes_api_calls:
     type: bool
     help: Will the backend make calls to an external API?
@@ -141,12 +144,6 @@ backend_uses_graphql:
 deploy_as_executable:
     type: bool
     help: Should this application be deployed as a single standalone executable?
-    default: no
-    when: "{{ has_backend }}"
-
-is_circuit_python_driver:
-    type: bool
-    help: Is this backend a CircuitPython device driver?
     default: no
     when: "{{ has_backend }}"
 

--- a/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
@@ -21,7 +21,7 @@ dependencies = [
     "httpx{% endraw %}{{ httpx_version }}{% raw %}",
     "microsoft-kiota-bundle{% endraw %}{{ python_kiota_bundle_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
     "pyserial>=3.5",
-    "psutil>=7.1.3",
+    "psutil>=7.2.2",
     "zeroconf>=0.148.0",
     "semver>=3.0.4",{% endraw %}{% endif %}{% raw %}
 ]

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -1,7 +1,8 @@
 {% raw %}import logging
 import os
 import threading
-import time
+import time{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from contextlib import asynccontextmanager{% endraw %}{% endif %}{% raw %}
 from importlib.metadata import version
 from pathlib import Path
 from typing import Any
@@ -13,7 +14,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi_offline import FastAPIOffline
 from pydantic import BaseModel
-from pydantic import Field
+from pydantic import Field{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from zeroconf.asyncio import AsyncZeroconf{% endraw %}{% endif %}{% raw %}
 
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -32,8 +32,49 @@ from .simulator_config_builder import build_simulator_config{% endraw %}{% endif
 logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).parent.parent
 VERSION = version("backend-api")
-STATIC_DIR = BASE_DIR / "static"
-try:
+STATIC_DIR = BASE_DIR / "static"{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+MDNS_REGISTRATION_PORT_ENV_VAR_NAME = "MDNS_REGISTRATION_PORT"
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        logger.info("Starting up FastAPI application")
+        azc = AsyncZeroconf()
+        try:
+            port = app.state.port
+        except AttributeError:
+            port = 4000  # when not invoking from the entrypoint, port may not have been set, so fall back to default dev port
+        assert isinstance(port, int), f"Expected port to be int, but got {port} of type {type(port)}"
+        mdns_port = int(os.getenv(MDNS_REGISTRATION_PORT_ENV_VAR_NAME, port))
+        await register_driver(azc=azc, port=mdns_port)
+        app.state.zc_browser = SimpleBrowser(azc)
+        app.state.simulator_config_builder = build_simulator_config
+    except (  # pragma: no cover # This is just logging unexpected errors, and it's very challenging to explicitly unit test
+        Exception
+    ):
+        logger.exception("Unhandled error inside lifespan function")
+        raise
+    try:
+        yield
+    finally:
+        # TODO: more robust teardown https://github.com/lab-sync/weight-sensor-driver/pull/6#discussion_r2523801189
+        await app.state.zc_browser.async_cancel()
+        await azc.async_unregister_all_services()
+        await azc.async_close()
+        servers_container = get_servers_container()
+        for driver in servers_container.drivers:
+            logger.info(f"Shutting down driver connected to {driver.connection_params}")
+            try:
+                driver.stop()
+            except (  # pragma: no cover # This is just logging unexpected errors. # TODO: see if we can unit test this
+                Exception
+            ):
+                logger.exception(f"Error shutting down driver with ID {driver.id}")
+    logger.info("Shutting down FastAPI application")
+
+
+{% endraw %}{% endif %}{% raw %}try:
     app = FastAPIOffline(
         title=HUMAN_FRIENDLY_APP_NAME,
         favicon_url="favicon.ico",

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -25,9 +25,9 @@ from .common.rfc_servers_jinja import get_servers_container
 from .driver_routes import router as driver_router{% endraw %}{% endif %}{% raw %}
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from .schema_def import schema
-from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
-from .simulator_config_builder import build_simulator_config{% endraw %}{% endif %}{% raw %}
+from .schema_def import schema{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from .simulator_config_builder import build_simulator_config{% endraw %}{% endif %}{% raw %}{% endraw %}{% if backend_uses_graphql %}{% raw %}
+from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}
 
 logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).parent.parent

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -1,7 +1,7 @@
 {% raw %}import logging
 import os
 import threading
-import time{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+import time{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 from contextlib import asynccontextmanager{% endraw %}{% endif %}{% raw %}
 from importlib.metadata import version
 from pathlib import Path
@@ -14,9 +14,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi_offline import FastAPIOffline
 from pydantic import BaseModel
-from pydantic import Field{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from pydantic import Field{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 from zeroconf.asyncio import AsyncZeroconf{% endraw %}{% endif %}{% raw %}
-{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 from .common.bridges import router as bridges_router
 from .common.mdns import SimpleBrowser
 from .common.mdns import register_driver
@@ -25,14 +25,14 @@ from .common.rfc_servers_jinja import get_servers_container
 from .driver_routes import router as driver_router{% endraw %}{% endif %}{% raw %}
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}
-from .schema_def import schema{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from .schema_def import schema{% endraw %}{% endif %}{% raw %}{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 from .simulator_config_builder import build_simulator_config{% endraw %}{% endif %}{% raw %}{% endraw %}{% if backend_uses_graphql %}{% raw %}
 from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}
 
 logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).parent.parent
 VERSION = version("backend-api")
-STATIC_DIR = BASE_DIR / "static"{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+STATIC_DIR = BASE_DIR / "static"{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 MDNS_REGISTRATION_PORT_ENV_VAR_NAME = "MDNS_REGISTRATION_PORT"
 
 
@@ -80,7 +80,7 @@ try:
         favicon_url="favicon.ico",
         version=VERSION,
         docs_url="/api-docs",
-        static_url="/static/swagger",{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+        static_url="/static/swagger",{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
         lifespan=lifespan,{% endraw %}{% endif %}{% raw %}
     )
 except (  # pragma: no cover # This is just logging unexpected errors, and it's very challenging to explicitly unit test
@@ -153,7 +153,7 @@ try:
     ){% endraw %}{% if backend_uses_graphql %}{% raw %}
 
     graphql_app = OfflineGraphQLRouter(schema)
-    app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+    app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
     app.include_router(driver_router, prefix="/api/driver")
     app.include_router(bridges_router, prefix="/api/bridges", tags=["debug"])
     app.include_router(mdns_router, prefix="/api", tags=["mDNS"]){% endraw %}{% endif %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any
 from typing import override
 
+{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
+from fastapi import FastAPI{% endraw %}{% endif %}{% raw %}
 from fastapi import Query
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -6,7 +6,6 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import Any
 from typing import override
-
 {% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
 from fastapi import FastAPI{% endraw %}{% endif %}{% raw %}
 from fastapi import Query

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -80,7 +80,8 @@ async def lifespan(app: FastAPI):
         favicon_url="favicon.ico",
         version=VERSION,
         docs_url="/api-docs",
-        static_url="/static/swagger",
+        static_url="/static/swagger",{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+        lifespan=lifespan,{% endraw %}{% endif %}{% raw %}
     )
 except (  # pragma: no cover # This is just logging unexpected errors, and it's very challenging to explicitly unit test
     Exception
@@ -152,7 +153,10 @@ try:
     ){% endraw %}{% if backend_uses_graphql %}{% raw %}
 
     graphql_app = OfflineGraphQLRouter(schema)
-    app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}
+    app.include_router(graphql_app, prefix="/api/graphql"){% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+    app.include_router(driver_router, prefix="/api/driver")
+    app.include_router(bridges_router, prefix="/api/bridges", tags=["debug"])
+    app.include_router(mdns_router, prefix="/api", tags=["mDNS"]){% endraw %}{% endif %}{% raw %}
     app.mount(
         "/", NoCacheStaticFiles(directory=STATIC_DIR, html=True), name="static"
     )  # this needs to go after any defined routes so that the routes take precedence

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -16,11 +16,18 @@ from fastapi_offline import FastAPIOffline
 from pydantic import BaseModel
 from pydantic import Field{% endraw %}{% if is_circuit_python_driver %}{% raw %}
 from zeroconf.asyncio import AsyncZeroconf{% endraw %}{% endif %}{% raw %}
-
+{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from .common.bridges import router as bridges_router
+from .common.mdns import SimpleBrowser
+from .common.mdns import register_driver
+from .common.mdns import router as mdns_router
+from .common.rfc_servers_jinja import get_servers_container
+from .driver_routes import router as driver_router{% endraw %}{% endif %}{% raw %}
 from .fast_api_exception_handlers import register_exception_handlers
 from .jinja_constants import HUMAN_FRIENDLY_APP_NAME{% endraw %}{% if backend_uses_graphql %}{% raw %}
 from .schema_def import schema
-from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}
+from .strawberry_router import OfflineGraphQLRouter{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+from .simulator_config_builder import build_simulator_config{% endraw %}{% endif %}{% raw %}
 
 logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).parent.parent

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -73,8 +73,8 @@ async def lifespan(app: FastAPI):
                 logger.exception(f"Error shutting down driver with ID {driver.id}")
     logger.info("Shutting down FastAPI application")
 
-
-{% endraw %}{% endif %}{% raw %}try:
+{% endraw %}{% endif %}{% raw %}
+try:
     app = FastAPIOffline(
         title=HUMAN_FRIENDLY_APP_NAME,
         favicon_url="favicon.ico",

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 8080
 backend_uses_graphql: true
 deploy_as_executable: false
 is_circuit_python_driver: true
+has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true
 frontend_uses_graphql: true
 frontend_deployed_port_number: 3000

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -35,6 +35,7 @@ backend_deployed_port_number: 4001
 backend_uses_graphql: false
 deploy_as_executable: false
 is_circuit_python_driver: false
+has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false
 frontend_uses_graphql: false
 frontend_deployed_port_number: 8000

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 4000
 backend_uses_graphql: false
 deploy_as_executable: false
 is_circuit_python_driver: false
+has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true
 frontend_uses_graphql: false
 frontend_deployed_port_number: 3000

--- a/tests/copier_data/data4.yaml
+++ b/tests/copier_data/data4.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 4020
 backend_uses_graphql: false
 deploy_as_executable: true
 is_circuit_python_driver: false
+has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false
 frontend_uses_graphql: false
 frontend_deployed_port_number: 3000


### PR DESCRIPTION
## Why is this change necessary?
There's a few tweaks to app_def.py that need to happen for circuit python drivers


## How does this change address the issue?
Adds in the imports, router mounting, and lifespan.

Reworks the copier questions to autofill in several responses if it's a circuit python driver.


## What side effects does this change have?
N/A


## How is this change tested?
Live in downstream repos---there's no way to test the conditional of `has_circuit_python_backend_template_been_instantiated` being true within this repo itself because it relies on a private copier template being instantiated...so be careful. But there's a pinned sha of this repo running in CI in that layered template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CircuitPython driver support with automatic service discovery and registration capabilities.
  * New API endpoints for driver and bridge management operations.

* **Dependencies**
  * Updated psutil minimum version requirement for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->