### PR TITLE
Conftest config for E2E tests for Drivers to enable running live tests

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
@@ -83,4 +83,41 @@ def running_application(backend_client_session: BackendClient):
         stop_compose()
     else:
         assert exe_process is not None
-        stop_exe(process=exe_process, port=backend_port){% endraw %}
+        stop_exe(process=exe_process, port=backend_port){% endraw %}{% if is_circuit_python_driver %}{% raw %}
+
+
+def pytest_addoption(parser: pytest.Parser):
+    group = parser.getgroup("live-device-testing")
+    group.addoption(
+        "--run-live-device-tests",
+        action="store_true",
+        default=False,
+        help="Enable live device testing. When set, requires communication bridge and device serial port options.",
+    )
+    group.addoption(
+        "--communication-bridge-host",
+        type=str,
+        default="127.0.0.1",
+        help="Where is the serial communication bridge hosted.",
+    )
+    group.addoption(
+        "--communication-bridge-port",
+        type=int,
+        help="Port where the serial communication bridge is hosted.",
+    )
+    group.addoption(
+        "--device-serial-port",
+        type=str,
+        help="Serial port to use for testing.",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]):
+    """Skip live device tests unless --run-live-device-tests is set."""
+    if config.getoption("--run-live-device-tests"):
+        return
+
+    skip_live_device = pytest.mark.skip(reason="Live device testing not enabled. Use --run-live-device-tests to run.")
+    for item in items:
+        if "live_device" in item.keywords:
+            item.add_marker(skip_live_device){% endraw %}{% endif %}{% raw %}{% endraw %}


### PR DESCRIPTION
## Why is this change necessary?
Need it in the template for all to use


## How does this change address the issue?
Backports it


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added pytest configuration options to control live device testing
  * Tests marked for live device execution are now automatically skipped unless explicitly enabled via command-line flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->