### PR TITLE
Add debug logging in CI for Helm

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -341,9 +341,20 @@ jobs:
           node-version: {% endraw %}{{ node_version }}{% raw %}
 
       - name: Wait for rollout
-        run: |
-          kubectl -n app rollout status deploy/e2e-{% endraw %}{{ repo_name }}{% raw %} --timeout=180s
-          kubectl -n app get pods -o wide
+        run: kubectl -n app rollout status deploy/e2e-{% endraw %}{{ repo_name }}{% raw %} --timeout=180s
+
+      - name: Diagnose rollout failure
+        if: failure()
+        run: kubectl -n app get pods -o wide
+      - name: Diagnose rollout failure - pod details
+        if: failure()
+        run: kubectl -n app describe pods
+      - name: Diagnose rollout failure - events
+        if: failure()
+        run: kubectl -n app get events --sort-by=.lastTimestamp
+      - name: Diagnose rollout failure - logs
+        if: failure()
+        run: kubectl -n app logs deploy/e2e-{% endraw %}{{ repo_name }}{% raw %} --all-containers --tail=100 --ignore-errors || true
 
       - name: E2E Test # TODO: add more than just smoke test
         run: |

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -336,6 +336,7 @@ jobs:
             --set env.frontend.BACKEND_HOST=$RUNNER_IP
 
       - name: Install latest versions of node packages
+        if: false # skip until we're ready to do real E2E tests that require it, to save time in CI runs for now
         uses: ./.github/actions/install_deps
         with:
           node-version: {% endraw %}{{ node_version }}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
@@ -6,6 +6,7 @@ import pytest
 import pytest_asyncio
 from backend_api import configure_logging
 from httpx import AsyncClient
+from httpx import Limits
 from kiota_abstractions.authentication.anonymous_authentication_provider import AnonymousAuthenticationProvider
 from kiota_http.httpx_request_adapter import HttpxRequestAdapter
 from pydantic import JsonValue
@@ -42,9 +43,15 @@ def pytest_configure(config: pytest.Config):
     config.pluginmanager.set_blocked("_cov")
 
 
+def _no_keepalive_limits() -> Limits:
+    # Uvicorn closes the HTTP/1.1 connection after a 500 response. Disabling keepalive
+    # ensures httpx never reuses a stale socket from a prior failed request.
+    return Limits(max_keepalive_connections=0)
+
+
 @pytest.fixture(scope="session")
 def backend_client_session() -> Generator[BackendClient]:
-    http_client = AsyncClient(base_url=f"http://localhost:{BACKEND_E2E_PORT}")
+    http_client = AsyncClient(base_url=f"http://localhost:{BACKEND_E2E_PORT}", limits=_no_keepalive_limits())
     try:
         request_adapter = HttpxRequestAdapter(AnonymousAuthenticationProvider(), http_client=http_client)
         yield BackendClient(request_adapter)
@@ -54,14 +61,18 @@ def backend_client_session() -> Generator[BackendClient]:
 
 @pytest_asyncio.fixture(scope="module")
 async def backend_client_module() -> AsyncGenerator[BackendClient]:
-    async with AsyncClient(base_url=f"http://localhost:{BACKEND_E2E_PORT}") as http_client:
+    async with AsyncClient(
+        base_url=f"http://localhost:{BACKEND_E2E_PORT}", limits=_no_keepalive_limits()
+    ) as http_client:
         request_adapter = HttpxRequestAdapter(AnonymousAuthenticationProvider(), http_client=http_client)
         yield BackendClient(request_adapter)
 
 
 @pytest_asyncio.fixture
 async def backend_client() -> AsyncGenerator[BackendClient]:
-    async with AsyncClient(base_url=f"http://localhost:{BACKEND_E2E_PORT}") as http_client:
+    async with AsyncClient(
+        base_url=f"http://localhost:{BACKEND_E2E_PORT}", limits=_no_keepalive_limits()
+    ) as http_client:
         request_adapter = HttpxRequestAdapter(AnonymousAuthenticationProvider(), http_client=http_client)
         yield BackendClient(request_adapter)
 


### PR DESCRIPTION
## Why is this change necessary?
Sometimes helm deployment randomly fails with no details


## How does this change address the issue?
Adds debug statements in CI


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo


## Other
There were issue with backend E2E tests where a test would have an API failure, and then an attempt in a cleanup fixture to use the same `client` fixture would error because the connection wouldn't work.  So disabling the keepalive during E2E tests

Disabled installing node dependencies in CI for k3d tests for now (to save time) since it's not used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test failure diagnostics to capture additional debugging information including pod details and deployment events.
  * Optimized HTTP client configuration for E2E testing environments.

* **Chores**
  * Updated CI workflow to provide more detailed failure insights during deployment testing phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->