### PR TITLE
More k3d CI job improvements

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -361,9 +361,9 @@ jobs:
       - name: E2E Test # TODO: add more than just smoke test
         run: |
           # since there's no gap after the rollout to install node dependencies, sometimes the NodePorts themselves aren't ready yet, so do a few retries
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused --retry-all-errors http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
 
   e2e-test-backend:
     name: End-to-end Testing of the Backend

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -361,9 +361,9 @@ jobs:
       - name: E2E Test # TODO: add more than just smoke test
         run: |
           # since there's no gap after the rollout to install node dependencies, sometimes the NodePorts themselves aren't ready yet, so do a few retries
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
-          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 --retry-connrefused http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
 
   e2e-test-backend:
     name: End-to-end Testing of the Backend

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -342,19 +342,20 @@ jobs:
           node-version: {% endraw %}{{ node_version }}{% raw %}
 
       - name: Wait for rollout
+        id: rollout
         run: kubectl -n app rollout status deploy/e2e-{% endraw %}{{ repo_name }}{% raw %} --timeout=180s
 
       - name: Diagnose rollout failure
-        if: failure()
+        if: ${{ failure() && steps.rollout.outcome == 'failure' }}
         run: kubectl -n app get pods -o wide
       - name: Diagnose rollout failure - pod details
-        if: failure()
+        if: ${{ failure() && steps.rollout.outcome == 'failure' }}
         run: kubectl -n app describe pods
       - name: Diagnose rollout failure - events
-        if: failure()
+        if: ${{ failure() && steps.rollout.outcome == 'failure' }}
         run: kubectl -n app get events --sort-by=.lastTimestamp
       - name: Diagnose rollout failure - logs
-        if: failure()
+        if: ${{ failure() && steps.rollout.outcome == 'failure' }}
         run: kubectl -n app logs deploy/e2e-{% endraw %}{{ repo_name }}{% raw %} --all-containers --tail=100 --ignore-errors || true
 
       - name: E2E Test # TODO: add more than just smoke test

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -361,9 +361,9 @@ jobs:
       - name: E2E Test # TODO: add more than just smoke test
         run: |
           # since there's no gap after the rollout to install node dependencies, sometimes the NodePorts themselves aren't ready yet, so do a few retries
-          curl --fail-with-body --retry 10 --retry-delay 2 --retry-all-errors http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
-          curl --fail-with-body --retry 10 --retry-delay 2 --retry-all-errors http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
-          curl --fail-with-body --retry 10 --retry-delay 2 --retry-all-errors http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ backend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/api/healthcheck
+          curl -s --show-error --fail-with-body --retry 10 --retry-delay 2 http://localhost:{% endraw %}{{ frontend_nodeport_number }}{% raw %}/{% endraw %}{% endif %}{% raw %}{% endraw %}{% if run_backend_e2e_in_ci %}{% raw %}
 
   e2e-test-backend:
     name: End-to-end Testing of the Backend

--- a/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/e2e/conftest.py.jinja
@@ -40,7 +40,17 @@ def vcr_config() -> dict[str, JsonValue]:
 
 def pytest_configure(config: pytest.Config):
     """Disable coverage reporting for E2E tests."""
-    config.pluginmanager.set_blocked("_cov")
+    config.pluginmanager.set_blocked("_cov"){% endraw %}{% if is_circuit_python_driver %}{% raw %}
+    config.addinivalue_line(
+        "markers", "live_device: mark test as requiring live device hardware (deselect with '-m \"not live_device\"')"
+    )
+
+    # Validate live device testing options
+    if config.getoption("--run-live-device-tests"):
+        if not config.getoption("--communication-bridge-port"):
+            raise pytest.UsageError("--communication-bridge-port is required when --run-live-device-tests is set")
+        if not config.getoption("--device-serial-port"):
+            raise pytest.UsageError("--device-serial-port is required when --run-live-device-tests is set"){% endraw %}{% endif %}{% raw %}
 
 
 def _no_keepalive_limits() -> Limits:


### PR DESCRIPTION
## Why is this change necessary?
Make it more robust


## How does this change address the issue?
Only attempts the rollout diagnostics if the rollout step failed


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


## Other
Backported some circuit python driver functionality to conftest.py for clearer errors if CLI flags messed up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced live-device test setup with required-parameter validation and clearer test marker description to ensure correct test environment and prevent misconfiguration.

* **Chores**
  * Improved CI diagnostics for failed rollouts to collect pod details, cluster events and recent logs only when a rollout explicitly fails.
  * Tightened E2E smoke checks by running curl quietly for cleaner output while preserving retry/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->