### PR TITLE
Even more k3d CI job improvements

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -331,13 +331,13 @@ jobs:
           k3d image import {% endraw %}{{ frontend_image_name }}{% raw %}:local {% endraw %}{% if has_backend %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %} -c e2e
           # k3d image import exits 0 even when the internal `ctr images import` exec inside the node
           # fails (e.g. containerd not fully ready after cluster creation). Verify and retry once.
-          if ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %} || ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}; then
+          if ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep -Fq -- {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %} || ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep -Fq -- {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}; then
             echo "Images not found after first import, retrying..."
             sleep 2
             k3d image import {% endraw %}{{ frontend_image_name }}{% raw %}:local {% endraw %}{% if has_backend %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %} -c e2e
           fi
-          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %}
-          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}
+          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep -Fq -- {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %}
+          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep -Fq -- {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}
 
       - name: Helm install
         run: |

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -314,6 +314,15 @@ jobs:
         with:
           version: {% endraw %}{{ kubectl_version }}{% raw %}
 
+      - name: Get runner IP
+        run: |
+          RUNNER_IP=$(hostname -I | awk '{print $1}')
+          echo "Runner IP: $RUNNER_IP"
+          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
+
+      - name: Create app namespace
+        run: kubectl create ns app
+
       - name: Wait for k3d node ready
         run: kubectl wait --for=condition=Ready node --all --timeout=60s
 
@@ -329,15 +338,6 @@ jobs:
           fi
           docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %}
           docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}
-
-      - name: Get runner IP
-        run: |
-          RUNNER_IP=$(hostname -I | awk '{print $1}')
-          echo "Runner IP: $RUNNER_IP"
-          echo "RUNNER_IP=$RUNNER_IP" >> $GITHUB_ENV
-
-      - name: Create app namespace
-        run: kubectl create ns app
 
       - name: Helm install
         run: |

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -314,8 +314,21 @@ jobs:
         with:
           version: {% endraw %}{{ kubectl_version }}{% raw %}
 
+      - name: Wait for k3d node ready
+        run: kubectl wait --for=condition=Ready node --all --timeout=60s
+
       - name: Import images into k3d
-        run: k3d image import {% endraw %}{{ frontend_image_name }}{% raw %}:local {% endraw %}{% if has_backend %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %} -c e2e
+        run: |
+          k3d image import {% endraw %}{{ frontend_image_name }}{% raw %}:local {% endraw %}{% if has_backend %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %} -c e2e
+          # k3d image import exits 0 even when the internal `ctr images import` exec inside the node
+          # fails (e.g. containerd not fully ready after cluster creation). Verify and retry once.
+          if ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %} || ! docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}; then
+            echo "Images not found after first import, retrying..."
+            sleep 2
+            k3d image import {% endraw %}{{ frontend_image_name }}{% raw %}:local {% endraw %}{% if has_backend %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %} -c e2e
+          fi
+          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ frontend_image_name }}{% raw %}:local{% endraw %}{% if has_backend %}{% raw %}
+          docker exec k3d-e2e-server-0 ctr -n k8s.io images ls | grep {% endraw %}{{ backend_image_name }}{% raw %}:local{% endraw %}{% endif %}{% raw %}
 
       - name: Get runner IP
         run: |


### PR DESCRIPTION
## Why is this change necessary?
The image import step would error internally but still succeed sometimes...meaning the helm chart couldn't actually deploy


## How does this change address the issue?
Adds a verification and retry for importing the images


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to wait for cluster nodes to reach Ready before importing images, to verify imported images are present inside the cluster, and to retry a failed import once. These changes improve reliability of end-to-end test runs by reducing intermittent image-import and timing-related failures during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->