### PR TITLE
Allow toggling UPX for pyinstaller builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,7 @@ jobs:
           '--data-file tests/copier_data/data2.yaml',
           '--data-file tests/copier_data/data3.yaml',
           '--data-file tests/copier_data/data4.yaml',
+          '--data-file tests/copier_data/data5.yaml',
           ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 8

--- a/copier.yml
+++ b/copier.yml
@@ -155,6 +155,12 @@ deploy_as_executable:
     default: no
     when: "{{ has_backend and not is_circuit_python_driver }}"
 
+use_upx_for_executable:
+    type: bool
+    help: Should UPX be used to compress the executable? On Windows this can make the compiled program smaller, but increases the risk of being flagged by antivirus software.
+    default: yes
+    when: "{{ deploy_as_executable }}"
+
 install_gcc_in_backend_container_build_phase:
     type: bool
     help: Is GCC required to build any Python dependencies in the backend container?

--- a/template/{% if has_backend %}backend{% endif %}/{% if deploy_as_executable %}pyinstaller.spec{% endif %}.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/{% if deploy_as_executable %}pyinstaller.spec{% endif %}.jinja
@@ -9,7 +9,7 @@ from fastapi_offline.core import _STATIC_PATH
 
 # https://stackoverflow.com/questions/37319911/python-how-to-specify-output-folders-in-pyinstaller-spec-file?rq=1
 
-use_upx = True
+use_upx = {% endraw %}{{ use_upx_for_executable }}{% raw %}
 
 block_cipher = None
 sys.modules["FixTk"] = None

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -29,6 +29,7 @@ backend_source_uses_kiota: true
 backend_deployed_port_number: 8080
 backend_uses_graphql: true
 deploy_as_executable: false
+use_upx_for_executable: false
 is_circuit_python_driver: true
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -34,6 +34,7 @@ backend_source_uses_kiota: false
 backend_deployed_port_number: 4001
 backend_uses_graphql: false
 deploy_as_executable: false
+use_upx_for_executable: false
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -29,6 +29,7 @@ backend_source_uses_kiota: false
 backend_deployed_port_number: 4000
 backend_uses_graphql: false
 deploy_as_executable: false
+use_upx_for_executable: false
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true

--- a/tests/copier_data/data4.yaml
+++ b/tests/copier_data/data4.yaml
@@ -29,6 +29,7 @@ backend_source_uses_kiota: false
 backend_deployed_port_number: 4020
 backend_uses_graphql: false
 deploy_as_executable: true
+use_upx_for_executable: true
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false

--- a/tests/copier_data/data5.yaml
+++ b/tests/copier_data/data5.yaml
@@ -1,0 +1,50 @@
+# Data managed by upstream template
+repo_name: tiny_exe
+repo_org_name: shrunken-labs
+is_open_source: false
+description: Executable without UPX compression
+install_claude_cli: false
+ssh_port_number: 9988
+pull_from_ecr: false
+repo_names_for_codespaces_read_permissions: ''
+use_windows_in_ci: false
+install_aws_ssm_port_forwarding_plugin: true
+configure_vcrpy: false
+configure_python_asyncio: true
+
+node_version: 24.11.1
+
+python_package_registry: PyPI
+aws_identity_center_id: d-9145c20053
+aws_org_home_region: eu-west-1
+aws_production_account_id: 987654321098
+use_staging_environment: false
+aws_region_for_stack: eu-west-1
+
+# Data added based on the specifics of this template
+human_friendly_app_name: Tiny Exe
+has_backend: true
+backend_makes_api_calls: false
+backend_source_uses_kiota: false
+backend_deployed_port_number: 5050
+backend_uses_graphql: false
+deploy_as_executable: true
+use_upx_for_executable: false
+is_circuit_python_driver: false
+has_circuit_python_backend_template_been_instantiated: false
+install_gcc_in_backend_container_build_phase: false
+frontend_uses_graphql: false
+frontend_deployed_port_number: 4000
+frontend_uses_zod: false
+push_to_ecr: false
+create_docker_image_tar_artifact: false
+frontend_ecr_base_url: 987654321098.dkr.ecr.eu-west-1.amazonaws.com
+frontend_ecr_push_role_name: n-a
+frontend_image_name: not/applicable
+backend_ecr_base_url: 987654321098.dkr.ecr.eu-west-1.amazonaws.com
+backend_ecr_push_role_name: n-a
+backend_image_name: not-applicable
+auth_to_ecr_for_e2e_in_ci: false
+run_backend_e2e_in_ci: false
+frontend_nodeport_number: 30600
+backend_nodeport_number: 30605

--- a/tests/copier_data/data5.yaml
+++ b/tests/copier_data/data5.yaml
@@ -34,7 +34,7 @@ is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false
 frontend_uses_graphql: false
-frontend_deployed_port_number: 4000
+frontend_deployed_port_number: 3500
 frontend_uses_zod: false
 push_to_ecr: false
 create_docker_image_tar_artifact: false


### PR DESCRIPTION
## Why is this change necessary?
Sometimes you don't want UPX used


## How does this change address the issue?
Adds a question in the copier template


## What side effects does this change have?
N/A


## How is this change tested?
CI and downstream repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable option to control UPX compression for executable builds (available when deploying as an executable, defaults to enabled).

* **Tests**
  * Expanded test coverage with additional data configurations to validate the new compression toggle across deployment scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/159)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->