### PR TITLE
Add version field for frontend if no backend

### DIFF
--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -1,5 +1,6 @@
 {% raw %}{
-  "name": "nuxt-app",
+  "name": "nuxt-app",{% endraw %}{% if not has_backend %}{% raw %}
+  "version": "0.1.0",{% endraw %}{% endif %}{% raw %}
   "private": true,
   "type": "module",
   "packageManager": "pnpm@{% endraw %}{{ pnpm_version }}{% raw %}",


### PR DESCRIPTION
## Why is this change necessary?
The release process needs something to look at


## How does this change address the issue?
If there is no backend, then create a version field in package.json of the frontend


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo that is frontend-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated frontend project template configuration generation to conditionally handle version field output based on project setup options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/162)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->