### PR TITLE
Backport changes from copier-circuit-python-device-driver-frontend

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -276,7 +276,8 @@ frontend_deployed_port_number:
 frontend_uses_zod:
     type: bool
     help: Will the frontend use the zod library for form validation?
-    default: false
+    default: "{{ is_circuit_python_driver }}"
+    when: "{{ not is_circuit_python_driver }}"
 
 frontend_nodeport_number:
     type: int

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -86,7 +86,7 @@ class ContextUpdater(ContextHook):
         context["vue_eslint_parser_version"] = "^10.4.0"
         context["happy_dom_version"] = "^20.9.0"
         context["node_kiota_bundle_version"] = "1.0.0-preview.100"
-        context["labsync_nuxt_common_version"] = "^0.0.5"
+        context["labsync_nuxt_common_version"] = "^0.1.0"
         context["tanstack_vue_table_version"] = "^8.21.3"
 
         context["gha_checkout"] = "v6.0.2"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -86,6 +86,8 @@ class ContextUpdater(ContextHook):
         context["vue_eslint_parser_version"] = "^10.4.0"
         context["happy_dom_version"] = "^20.9.0"
         context["node_kiota_bundle_version"] = "1.0.0-preview.100"
+        context["labsync_nuxt_common_version"] = "^0.0.5"
+        context["tanstack_vue_table_version"] = "^8.21.3"
 
         context["gha_checkout"] = "v6.0.2"
         context["gha_setup_python"] = "v6.2.0"

--- a/template/frontend/nuxt.config.ts.jinja
+++ b/template/frontend/nuxt.config.ts.jinja
@@ -13,7 +13,8 @@ export default defineNuxtConfig({
   // the conditional modules added in by the template make it complicated to format consistently...at least with only 3 'always included' modules
   // prettier-ignore
   modules: [
-    "@nuxt/ui"{% endraw %}{% if frontend_uses_graphql %}{% raw %},
+    {% endraw %}{% if is_circuit_python_driver %}{% raw %}"@lab-sync/nuxt-common",
+    {% endraw %}{% endif %}{% raw %}"@nuxt/ui"{% endraw %}{% if frontend_uses_graphql %}{% raw %},
     "@nuxtjs/apollo"{% endraw %}{% endif %}{% raw %},
     ["@nuxt/eslint", { devOnly: true }],
     ["@nuxt/test-utils/module", { devOnly: true }],

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -35,7 +35,9 @@
     "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}",
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
-    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if frontend_uses_zod %}{% raw %},
+    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver %}{% raw %},
+    "@lab-sync/nuxt-common": "{% endraw %}{{ labsync_nuxt_common_version }}{% raw %}",
+    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "zod": "{% endraw %}{{ zod_version }}{% raw %}",
     "zod-from-json-schema": "{% endraw %}{{ zod_from_json_schema_version }}{% raw %}"{% endraw %}{% endif %}{% raw %}
   },

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -36,8 +36,8 @@
     "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}",
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
-    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver %}{% raw %},
-    "zod": "{% endraw %}{{ zod_version }}{% raw %}",
+    "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver or frontend_uses_zod %}{% raw %},
+    "zod": "{% endraw %}{{ zod_version }}{% raw %}"{% endraw %}{% endif %}{% if is_circuit_python_driver %}{% raw %},
     "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "zod-from-json-schema": "{% endraw %}{{ zod_from_json_schema_version }}{% raw %}"{% endraw %}{% endif %}{% raw %}
   },

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -33,7 +33,7 @@
     "@nuxt/fonts": "{% endraw %}{{ nuxt_fonts_version }}{% raw %}",
     "@nuxt/icon": "{% endraw %}{{ nuxt_icon_version }}{% raw %}",
     "@nuxt/ui": "{% endraw %}{{ nuxt_ui_version }}{% raw %}",
-    "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}"{% endraw %}{% endif %}{% if is_circuit_python_driver %}{% raw %},
+    "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver %}{% raw %},
     "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% raw %},
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@iconify-json/lucide": "{% endraw %}{{ iconify_json_lucide_version }}{% raw %}",
-    "@iconify/vue": "{% endraw %}{{ iconify_vue_version }}{% raw %}",
-    "@lab-sync/nuxt-common": "{% endraw %}{{ labsync_nuxt_common_version }}{% raw %}",
+    "@iconify/vue": "{% endraw %}{{ iconify_vue_version }}{% raw %}",{% endraw %}{% if is_circuit_python_driver %}{% raw %}
+    "@lab-sync/nuxt-common": "{% endraw %}{{ labsync_nuxt_common_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
     "@microsoft/kiota-abstractions": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
     "@microsoft/kiota-bundle": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
     "@microsoft/kiota-http-fetchlibrary": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
@@ -34,11 +34,11 @@
     "@nuxt/icon": "{% endraw %}{{ nuxt_icon_version }}{% raw %}",
     "@nuxt/ui": "{% endraw %}{{ nuxt_ui_version }}{% raw %}",
     "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}",
-    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
     "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver %}{% raw %},
     "zod": "{% endraw %}{{ zod_version }}{% raw %}",
+    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "zod-from-json-schema": "{% endraw %}{{ zod_from_json_schema_version }}{% raw %}"{% endraw %}{% endif %}{% raw %}
   },
   "devDependencies": {

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -26,6 +26,7 @@
   "dependencies": {
     "@iconify-json/lucide": "{% endraw %}{{ iconify_json_lucide_version }}{% raw %}",
     "@iconify/vue": "{% endraw %}{{ iconify_vue_version }}{% raw %}",
+    "@lab-sync/nuxt-common": "{% endraw %}{{ labsync_nuxt_common_version }}{% raw %}",
     "@microsoft/kiota-abstractions": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
     "@microsoft/kiota-bundle": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
     "@microsoft/kiota-http-fetchlibrary": "{% endraw %}{{ node_kiota_bundle_version }}{% raw %}",
@@ -33,11 +34,10 @@
     "@nuxt/icon": "{% endraw %}{{ nuxt_icon_version }}{% raw %}",
     "@nuxt/ui": "{% endraw %}{{ nuxt_ui_version }}{% raw %}",
     "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}",
+    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
     "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver %}{% raw %},
-    "@lab-sync/nuxt-common": "{% endraw %}{{ labsync_nuxt_common_version }}{% raw %}",
-    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "zod": "{% endraw %}{{ zod_version }}{% raw %}",
     "zod-from-json-schema": "{% endraw %}{{ zod_from_json_schema_version }}{% raw %}"{% endraw %}{% endif %}{% raw %}
   },

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -33,12 +33,12 @@
     "@nuxt/fonts": "{% endraw %}{{ nuxt_fonts_version }}{% raw %}",
     "@nuxt/icon": "{% endraw %}{{ nuxt_icon_version }}{% raw %}",
     "@nuxt/ui": "{% endraw %}{{ nuxt_ui_version }}{% raw %}",
-    "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}",
+    "@nuxtjs/color-mode": "{% endraw %}{{ nuxtjs_color_mode_version }}{% raw %}"{% endraw %}{% endif %}{% if is_circuit_python_driver %}{% raw %},
+    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% raw %},
     "nuxt": "{% endraw %}{{ nuxt_version }}{% raw %}",
     "vue": "{% endraw %}{{ vue_version }}{% raw %}",
     "vue-router": "{% endraw %}{{ vue_router_version }}{% raw %}"{% endraw %}{% if is_circuit_python_driver or frontend_uses_zod %}{% raw %},
-    "zod": "{% endraw %}{{ zod_version }}{% raw %}"{% endraw %}{% endif %}{% if is_circuit_python_driver %}{% raw %},
-    "@tanstack/vue-table": "{% endraw %}{{ tanstack_vue_table_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
+    "zod": "{% endraw %}{{ zod_version }}{% raw %}"{% endraw %}{% endif %}{% if frontend_uses_zod %}{% raw %},
     "zod-from-json-schema": "{% endraw %}{{ zod_from_json_schema_version }}{% raw %}"{% endraw %}{% endif %}{% raw %}
   },
   "devDependencies": {

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}schema_def.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}schema_def.py{% endif %}
@@ -7,6 +7,6 @@ from .strawberry_router import AddErrorTrace
 
 logger = logging.getLogger(__name__)
 
-schema = strawberry.Schema(query=int, extensions=[AddErrorTrace()])
+schema = strawberry.Schema(query=int, extensions=[AddErrorTrace])
 sdl_path = Path(__file__).parent / "schema.graphql"
 _ = sdl_path.write_text(f"{schema.as_str()}\n")

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_strawberry_exception_handler.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/{% if backend_uses_graphql %}test_strawberry_exception_handler.py{% endif %}
@@ -31,7 +31,7 @@ class Query:
         return _run_other_logic(value)
 
 
-schema = strawberry.Schema(query=Query, extensions=[AddErrorTrace()])
+schema = strawberry.Schema(query=Query, extensions=[AddErrorTrace])
 
 GQL = """query ($value: String!) {
                 doSomething(value: $value)


### PR DESCRIPTION
## Link to Issue or Message thread
Pow wow from this morning with @ejfine 


## Why is this change necessary?
Instead of having a custom package.json and nuxt-config being generated for circuit python frontends we should use the var we have already to simplify things.


## How does this change address the issue?
Pulls those changes up


## What side effects does this change have?
Since frontend needs zod for the circuit python also use default/when for that question if you have a circuit python driver


## How is this change tested?
Downstream



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frontend modules and dependencies are now conditionally included based on project type.
  * Template context exposes additional frontend package version variables for more consistent scaffolding.

* **Chores**
  * Prompting and default behavior for frontend validation option adjusted to better match project type.

* **Bug Fixes**
  * GraphQL schema extension handling corrected to ensure consistent error-tracing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->