### PR TITLE
Move openapi.json path

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-5-g1f6dc64
+_commit: v0.0.125-6-gfd62769
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-6-gfd62769
+_commit: v0.0.125-7-g629d3c8
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-13-ga2641ea
+_commit: v0.0.125-18-g5070aa5
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-7-g629d3c8
+_commit: v0.0.125-13-ga2641ea
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,7 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.124
+_commit: v0.0.125-5-g1f6dc64
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
+copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose
 install_claude_cli: true

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.123-8-g78bd0b4
+_commit: v0.0.124
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-18-g5070aa5
+_commit: v0.0.125-23-g03c9c46
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.123
+_commit: v0.0.123-7-gc8b6b85
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.125-23-g03c9c46
+_commit: v0.0.126
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.123-7-gc8b6b85
+_commit: v0.0.123-8-g78bd0b4
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: A web app that is hosted within a local intranet. Nuxt frontend, python
     backend, docker-compose

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): eac098a2 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 8321ea8d # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 9adaea8e # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 9adcea8e # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,5 +65,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 8321ea8d # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 9adaea8e # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -8,8 +8,8 @@ import tempfile
 from pathlib import Path
 
 UV_VERSION = "0.11.14"
-PNPM_VERSION = "11.1.2"
-COPIER_VERSION = "==9.15.0"
+PNPM_VERSION = "11.1.3"
+COPIER_VERSION = "==9.15.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "==0.3.3"
 PRE_COMMIT_VERSION = "4.5.1"
 GITHUB_WINDOWS_RUNNER_BIN_PATH = r"C:\Users\runneradmin\.local\bin"

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -8,7 +8,7 @@ import tempfile
 from pathlib import Path
 
 UV_VERSION = "0.11.14"
-PNPM_VERSION = "11.1.3"
+PNPM_VERSION = "11.2.2"
 COPIER_VERSION = "==9.15.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "==0.3.3"
 PRE_COMMIT_VERSION = "4.5.1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,14 @@ jobs:
       - name: Instantiate copier template
         run: |
           copier copy --trust --vcs-ref ${{ github.sha }} ${{ matrix.copier }} --data python_version=${{ matrix.python-version }} . ./new-template
+
+      - name: Confirm instantiated template has copier answers file
+        run: |
+          if [ ! -f "./new-template/./.copier-answers.yml" ]; then
+            echo "Copier answers file not found in instantiated template location"
+            exit 1
+          fi
+
       - name: Delete files from initial repo
         run: |
           # Delete everything except the folder containing the instantiated template
@@ -144,6 +152,7 @@ jobs:
           rm -rf .devcontainer # apparently this folder doesn't get removed with the previous command for some reason
           rm -rf .claude # apparently this folder doesn't get removed with the previous command for some reason
           ls -la
+
       - name: Move the instantiated template into the repo root
         run: |
           # Move all the files from the instantiated template out of the subfolder

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,7 @@ jobs:
         uses: ./.github/actions/install_deps
         with:
           python-version: ${{ matrix.python-version }}
+          node-version: 24.11.1
 
       - name: Run Unit Tests
         # TODO: figure out what to do about tests of copier task scripts that don't actually get detected by code coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ This project is a Copier template used to generate applications that are able to
 ## Tooling
 
 - ❌ Never chain commands (`&&`, `||`, `;`, `&`) — breaks permission allow-list matcher. ✅ One command per tool call. `cd` as separate prior call. Pipes (`|`) OK.
+- `cd` into a subdirectory is auto-approved; navigating up (`cd ..`) or to an absolute path (`cd /some/path`) requires a user permission prompt. Minimize such navigation: run `pre-commit` from whichever subdirectory you're already in (it walks up to find `.pre-commit-config.yaml`).
 - ❌ Never use `python3` or `python` directly. ✅ Always use `uv run python` for Python commands.
 - ❌ Never use `python3`/`python` for one-off data tasks. ✅ Use `jq` for JSON parsing, standard shell builtins for string manipulation. Only reach for `uv run python` when no dedicated tool covers the need.
 - ❌ Never use `uv run python -c "import ...; print(...)"` or `inspect` to introspect Python source. ✅ Read source files directly or grep for symbols — the code is on disk and can be read without running it.

--- a/copier.yml
+++ b/copier.yml
@@ -161,6 +161,12 @@ use_upx_for_executable:
     default: yes
     when: "{{ deploy_as_executable }}"
 
+install_as_windows_service:
+    type: bool
+    help: Should this application be installable as a Windows service?
+    default: "{{ deploy_as_executable and use_windows_in_ci }}"
+    when: "{{ deploy_as_executable and use_windows_in_ci }}"
+
 install_gcc_in_backend_container_build_phase:
     type: bool
     help: Is GCC required to build any Python dependencies in the backend container?

--- a/copier.yml
+++ b/copier.yml
@@ -338,26 +338,7 @@ _tasks:
                 chmod +x "$script"
             fi
         done
-  - command: |
-        if [ -f pnpm-workspace.yaml ]; then
-            IFS=',' read -r -a _mrae_parts <<< '{{ pnpm_minimum_release_age_exclude }}'
-            if ! grep -q '^minimumReleaseAgeExclude:' pnpm-workspace.yaml; then
-                printf '\nminimumReleaseAgeExclude:\n' >> pnpm-workspace.yaml
-                for _mrae_part in "${_mrae_parts[@]}"; do
-                    _mrae_pat="${_mrae_part#"${_mrae_part%%[![:space:]]*}"}"
-                    _mrae_pat="${_mrae_pat%"${_mrae_pat##*[![:space:]]}"}"
-                    [ -n "$_mrae_pat" ] && printf '  - %s\n' "$_mrae_pat" >> pnpm-workspace.yaml
-                done
-            else
-                for _mrae_part in "${_mrae_parts[@]}"; do
-                    _mrae_pat="${_mrae_part#"${_mrae_part%%[![:space:]]*}"}"
-                    _mrae_pat="${_mrae_pat%"${_mrae_pat##*[![:space:]]}"}"
-                    if [ -n "$_mrae_pat" ] && ! grep -qF "  - ${_mrae_pat}" pnpm-workspace.yaml; then
-                        sed -i "/^minimumReleaseAgeExclude:/a\\  - ${_mrae_pat}" pnpm-workspace.yaml
-                    fi
-                done
-            fi
-        fi
+  - command: python3 '{{ _copier_conf.src_path }}/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py' --patterns '{{ pnpm_minimum_release_age_exclude }}'
     when: "{{ pnpm_minimum_release_age_exclude }}"
   - command: |
         if [ -f ruff.toml ]; then

--- a/copier.yml
+++ b/copier.yml
@@ -62,6 +62,11 @@ node_version:
     help: What version of NodeJS is used for development?
     default: "{{ default_node_version }}"
 
+pnpm_minimum_release_age_exclude:
+    type: str
+    help: "Comma-delimited list of package name patterns to exclude from pnpm's minimumReleaseAge constraint (leave empty for none)"
+    default: ""
+
 
 install_aws_ssm_port_forwarding_plugin:
     type: bool
@@ -333,6 +338,27 @@ _tasks:
                 chmod +x "$script"
             fi
         done
+  - command: |
+        if [ -f pnpm-workspace.yaml ]; then
+            IFS=',' read -r -a _mrae_parts <<< '{{ pnpm_minimum_release_age_exclude }}'
+            if ! grep -q '^minimumReleaseAgeExclude:' pnpm-workspace.yaml; then
+                printf '\nminimumReleaseAgeExclude:\n' >> pnpm-workspace.yaml
+                for _mrae_part in "${_mrae_parts[@]}"; do
+                    _mrae_pat="${_mrae_part#"${_mrae_part%%[![:space:]]*}"}"
+                    _mrae_pat="${_mrae_pat%"${_mrae_pat##*[![:space:]]}"}"
+                    [ -n "$_mrae_pat" ] && printf '  - %s\n' "$_mrae_pat" >> pnpm-workspace.yaml
+                done
+            else
+                for _mrae_part in "${_mrae_parts[@]}"; do
+                    _mrae_pat="${_mrae_part#"${_mrae_part%%[![:space:]]*}"}"
+                    _mrae_pat="${_mrae_pat%"${_mrae_pat##*[![:space:]]}"}"
+                    if [ -n "$_mrae_pat" ] && ! grep -qF "  - ${_mrae_pat}" pnpm-workspace.yaml; then
+                        sed -i "/^minimumReleaseAgeExclude:/a\\  - ${_mrae_pat}" pnpm-workspace.yaml
+                    fi
+                done
+            fi
+        fi
+    when: "{{ pnpm_minimum_release_age_exclude }}"
   - command: |
         if [ -f ruff.toml ]; then
             echo "Updating ruff target-version from python_version..."

--- a/copier.yml
+++ b/copier.yml
@@ -338,7 +338,9 @@ _tasks:
                 chmod +x "$script"
             fi
         done
-  - command: python3 '{{ _copier_conf.src_path }}/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py' --patterns '{{ pnpm_minimum_release_age_exclude }}'
+  - command: |
+        export PNPM_PATTERNS='{{ pnpm_minimum_release_age_exclude }}'
+        python3 '{{ _copier_conf.src_path }}/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py' --patterns "$PNPM_PATTERNS"
     when: "{{ pnpm_minimum_release_age_exclude }}"
   - command: |
         if [ -f ruff.toml ]; then

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -13,7 +13,7 @@ class ContextUpdater(ContextHook):
         self, context: dict[Any, Any]
     ) -> dict[Any, Any]:
         context["uv_version"] = "0.11.14"
-        context["pnpm_version"] = "11.1.3"
+        context["pnpm_version"] = "11.2.2"
         context["npm_version"] = "11.13.0"
         context["nvm_version"] = "0.40.4"
         context["pre_commit_version"] = "4.5.1"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -13,7 +13,7 @@ class ContextUpdater(ContextHook):
         self, context: dict[Any, Any]
     ) -> dict[Any, Any]:
         context["uv_version"] = "0.11.14"
-        context["pnpm_version"] = "11.1.2"
+        context["pnpm_version"] = "11.1.3"
         context["npm_version"] = "11.13.0"
         context["nvm_version"] = "0.40.4"
         context["pre_commit_version"] = "4.5.1"
@@ -21,8 +21,8 @@ class ContextUpdater(ContextHook):
         context["pytest_version"] = ">=9.0.3"
         context["pytest_randomly_version"] = ">=4.1.0"
         context["pytest_cov_version"] = ">=7.1.0"
-        context["ty_version"] = ">=0.0.34"
-        context["copier_version"] = "==9.15.0"
+        context["ty_version"] = ">=0.0.37"
+        context["copier_version"] = "==9.15.1"
         context["copier_template_extensions_version"] = "==0.3.3"
         context["sphinx_version"] = "9.0.4"
         context["pulumi_version"] = ">=3.234.0"
@@ -39,11 +39,11 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = ">=0.298.0"
         context["fastapi_version"] = ">=0.136.1"
         context["fastapi_offline_version"] = ">=1.7.4"
-        context["uvicorn_version"] = ">=0.46.0"
+        context["uvicorn_version"] = ">=0.47.0"
         context["lab_auto_pulumi_version"] = ">=0.2.0"
         context["ariadne_codegen_version"] = ">=0.18.0"
         context["pytest_mock_version"] = ">=3.15.1"
-        context["uuid_utils_version"] = ">=0.14.0"
+        context["uuid_utils_version"] = ">=0.16.0"
         context["syrupy_version"] = ">=5.2.0"
         context["structlog_version"] = ">=25.5.0"
         context["httpx_version"] = ">=0.28.1"
@@ -61,7 +61,7 @@ class ContextUpdater(ContextHook):
         context["typescript_version"] = "^5.9.3"
         context["playwright_version"] = "^1.60.0"
         context["vue_version"] = "^3.5.30"
-        context["vue_tsc_version"] = "^3.2.4"
+        context["vue_tsc_version"] = "^3.3.0"
         context["vue_devtools_api_version"] = "^8.1.0"
         context["vue_router_version"] = "^5.0.3"
         context["dotenv_cli_version"] = "^11.0.0"
@@ -120,7 +120,7 @@ class ContextUpdater(ContextHook):
 
         context["debian_release_name"] = "trixie"
         context["alpine_image_version"] = "3.23"
-        context["nginx_image_version"] = "1.29.4"
+        context["nginx_image_version"] = "1.30.1"
 
         context["kiota_cli_version"] = "1.31.1"
 

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -21,7 +21,7 @@ class ContextUpdater(ContextHook):
         context["pytest_version"] = ">=9.0.3"
         context["pytest_randomly_version"] = ">=4.1.0"
         context["pytest_cov_version"] = ">=7.1.0"
-        context["ty_version"] = ">=0.0.37"
+        context["ty_version"] = ">=0.0.38"
         context["copier_version"] = "==9.15.1"
         context["copier_template_extensions_version"] = "==0.3.3"
         context["sphinx_version"] = "9.0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
     "pyright[nodejs]>=1.1.409",
-    "ty>=0.0.34",
-    "copier==9.15.0",
+    "ty>=0.0.37",
+    "copier==9.15.1",
     "copier-template-extensions==0.3.3"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
     "pyright[nodejs]>=1.1.409",
-    "ty>=0.0.37",
+    "ty>=0.0.38",
     "copier==9.15.1",
     "copier-template-extensions==0.3.3"
 ]

--- a/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
+++ b/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def _parse_patterns(raw: str) -> list[str]:
-    return [p.strip() for p in raw.split(",") if p.strip()]
+    return [p.strip().strip('"').strip("'") for p in raw.split(",") if p.strip()]
 
 
 def _pattern_present(lines: list[str], pattern: str) -> bool:
@@ -28,33 +28,21 @@ def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[s
 
     lines = text.splitlines(keepends=True)
     missing = [p for p in patterns if not _pattern_present(lines, p)]
-
     if not missing:
         return
-
     for i, line in enumerate(lines):
         if re.match(r"^minimumReleaseAgeExclude:", line):
             for j, pattern in enumerate(missing):
                 lines.insert(i + 1 + j, f'  - "{pattern}"\n')
             break
-
     _ = workspace_path.write_text("".join(lines), encoding="utf-8")
     print(f"Added {len(missing)} missing pattern(s): {', '.join(missing)}")  # noqa: T201 -- copier task output must reach the user
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    _ = parser.add_argument(
-        "--patterns",
-        required=True,
-        help="Comma-delimited list of package name patterns to ensure are present.",
-    )
-    _ = parser.add_argument(
-        "--target-file",
-        default="pnpm-workspace.yaml",
-        dest="target_file",
-        help="Path to the pnpm-workspace.yaml file (default: pnpm-workspace.yaml).",
-    )
+    _ = parser.add_argument("--patterns", required=True)
+    _ = parser.add_argument("--target-file", default="pnpm-workspace.yaml", dest="target_file")
     return parser.parse_args()
 
 

--- a/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
+++ b/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
@@ -1,0 +1,71 @@
+import argparse
+import re
+from pathlib import Path
+
+
+def _parse_patterns(raw: str) -> list[str]:
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _pattern_present(lines: list[str], pattern: str) -> bool:
+    return any(re.match(rf"^\s+-\s+{re.escape(pattern)}\s*$", line) for line in lines)
+
+
+def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[str]) -> None:
+    if not workspace_path.exists():
+        print(f"{workspace_path} not found; skipping.")  # noqa: T201 -- copier task output must reach the user
+        return
+
+    text = workspace_path.read_text(encoding="utf-8")
+
+    if not re.search(r"^minimumReleaseAgeExclude:", text, re.MULTILINE):
+        addition = "\nminimumReleaseAgeExclude:\n"
+        for p in patterns:
+            addition += f"  - {p}\n"
+        _ = workspace_path.write_text(text.rstrip("\n") + "\n" + addition, encoding="utf-8")
+        print(f"Added minimumReleaseAgeExclude section with {len(patterns)} pattern(s).")  # noqa: T201 -- copier task output must reach the user
+        return
+
+    lines = text.splitlines(keepends=True)
+    missing = [p for p in patterns if not _pattern_present(lines, p)]
+
+    if not missing:
+        return
+
+    for i, line in enumerate(lines):
+        if re.match(r"^minimumReleaseAgeExclude:", line):
+            for j, pattern in enumerate(missing):
+                lines.insert(i + 1 + j, f"  - {pattern}\n")
+            break
+
+    _ = workspace_path.write_text("".join(lines), encoding="utf-8")
+    print(f"Added {len(missing)} missing pattern(s): {', '.join(missing)}")  # noqa: T201 -- copier task output must reach the user
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument(
+        "--patterns",
+        required=True,
+        help="Comma-delimited list of package name patterns to ensure are present.",
+    )
+    _ = parser.add_argument(
+        "--target-file",
+        default="pnpm-workspace.yaml",
+        dest="target_file",
+        help="Path to the pnpm-workspace.yaml file (default: pnpm-workspace.yaml).",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    ensure_minimum_release_age_exclude(
+        workspace_path=Path(args.target_file),
+        patterns=_parse_patterns(args.patterns),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
+++ b/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
@@ -8,7 +8,7 @@ def _parse_patterns(raw: str) -> list[str]:
 
 
 def _pattern_present(lines: list[str], pattern: str) -> bool:
-    return any(re.match(rf"^\s+-\s+{re.escape(pattern)}\s*$", line) for line in lines)
+    return any(re.match(rf'^\s+-\s+"?{re.escape(pattern)}"?\s*$', line) for line in lines)
 
 
 def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[str]) -> None:
@@ -21,7 +21,7 @@ def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[s
     if not re.search(r"^minimumReleaseAgeExclude:", text, re.MULTILINE):
         addition = "\nminimumReleaseAgeExclude:\n"
         for p in patterns:
-            addition += f"  - {p}\n"
+            addition += f'  - "{p}"\n'
         _ = workspace_path.write_text(text.rstrip("\n") + "\n" + addition, encoding="utf-8")
         print(f"Added minimumReleaseAgeExclude section with {len(patterns)} pattern(s).")  # noqa: T201 -- copier task output must reach the user
         return
@@ -35,7 +35,7 @@ def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[s
     for i, line in enumerate(lines):
         if re.match(r"^minimumReleaseAgeExclude:", line):
             for j, pattern in enumerate(missing):
-                lines.insert(i + 1 + j, f"  - {pattern}\n")
+                lines.insert(i + 1 + j, f'  - "{pattern}"\n')
             break
 
     _ = workspace_path.write_text("".join(lines), encoding="utf-8")

--- a/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
+++ b/src/copier_tasks/ensure_pnpm_minimum_release_age_exclude.py
@@ -1,55 +1,55 @@
 import argparse
-import re
+import shutil
+import subprocess
 from pathlib import Path
+
+_EXIT_CODE_PNPM_NOT_FOUND = 1
+_WORKSPACE_FILENAME = "pnpm-workspace.yaml"
 
 
 def _parse_patterns(raw: str) -> list[str]:
     return [p.strip().strip('"').strip("'") for p in raw.split(",") if p.strip()]
 
 
-def _pattern_present(lines: list[str], pattern: str) -> bool:
-    return any(re.match(rf'^\s+-\s+"?{re.escape(pattern)}"?\s*$', line) for line in lines)
+def ensure_minimum_release_age_exclude(*, workspace_dir: Path, patterns: list[str]) -> None:
+    if shutil.which("pnpm") is None:
+        print(  # noqa: T201 -- copier task output must reach the user
+            "pnpm not found on PATH; cannot update minimumReleaseAgeExclude. Install pnpm and try again: npm install -g pnpm"
+        )
+        raise SystemExit(_EXIT_CODE_PNPM_NOT_FOUND)
 
-
-def ensure_minimum_release_age_exclude(*, workspace_path: Path, patterns: list[str]) -> None:
-    if not workspace_path.exists():
-        print(f"{workspace_path} not found; skipping.")  # noqa: T201 -- copier task output must reach the user
+    if not (workspace_dir / _WORKSPACE_FILENAME).exists():
+        print(f"{workspace_dir / _WORKSPACE_FILENAME} not found; skipping.")  # noqa: T201 -- copier task output must reach the user
         return
 
-    text = workspace_path.read_text(encoding="utf-8")
-
-    if not re.search(r"^minimumReleaseAgeExclude:", text, re.MULTILINE):
-        addition = "\nminimumReleaseAgeExclude:\n"
-        for p in patterns:
-            addition += f'  - "{p}"\n'
-        _ = workspace_path.write_text(text.rstrip("\n") + "\n" + addition, encoding="utf-8")
-        print(f"Added minimumReleaseAgeExclude section with {len(patterns)} pattern(s).")  # noqa: T201 -- copier task output must reach the user
-        return
-
-    lines = text.splitlines(keepends=True)
-    missing = [p for p in patterns if not _pattern_present(lines, p)]
-    if not missing:
-        return
-    for i, line in enumerate(lines):
-        if re.match(r"^minimumReleaseAgeExclude:", line):
-            for j, pattern in enumerate(missing):
-                lines.insert(i + 1 + j, f'  - "{pattern}"\n')
-            break
-    _ = workspace_path.write_text("".join(lines), encoding="utf-8")
-    print(f"Added {len(missing)} missing pattern(s): {', '.join(missing)}")  # noqa: T201 -- copier task output must reach the user
+    get_result = subprocess.run(
+        ["pnpm", "config", "--location", "project", "get", "minimumReleaseAgeExclude"],  # noqa: S607 -- pnpm is a trusted tool, not user input
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=workspace_dir,
+    )
+    raw_existing = get_result.stdout.strip()
+    existing = _parse_patterns(raw_existing) if raw_existing != "undefined" else []
+    merged = existing + [p for p in patterns if p not in existing]
+    _ = subprocess.run(  # noqa: S603 -- merged patterns come from pnpm config get and CLI input, both trusted in this copier task context
+        ["pnpm", "config", "--location", "project", "set", "minimumReleaseAgeExclude", ",".join(merged)],  # noqa: S607 -- pnpm is a trusted tool, not user input
+        check=True,
+        cwd=workspace_dir,
+    )
 
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     _ = parser.add_argument("--patterns", required=True)
-    _ = parser.add_argument("--target-file", default="pnpm-workspace.yaml", dest="target_file")
+    _ = parser.add_argument("--target-dir", default=".", dest="target_dir")
     return parser.parse_args()
 
 
 def main() -> int:
     args = _parse_args()
     ensure_minimum_release_age_exclude(
-        workspace_path=Path(args.target_file),
+        workspace_dir=Path(args.target_dir),
         patterns=_parse_patterns(args.patterns),
     )
     return 0

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -77,6 +77,7 @@
 ## Tooling
 
 - ❌ Never chain commands (`&&`, `||`, `;`, `&`) — breaks permission allow-list matcher. ✅ One command per tool call. `cd` as separate prior call. Pipes (`|`) OK.
+- `cd` into a subdirectory is auto-approved; navigating up (`cd ..`) or to an absolute path (`cd /some/path`) requires a user permission prompt. Minimize such navigation: run `pre-commit` from whichever subdirectory you're already in (it walks up to find `.pre-commit-config.yaml`).
 - ❌ Never use `python3` or `python` directly. ✅ Always use `uv run python` for Python commands.
 - ❌ Never use `python3`/`python` for one-off data tasks. ✅ Use `jq` for JSON parsing, standard shell builtins for string manipulation. Only reach for `uv run python` when no dedicated tool covers the need.
 - ❌ Never use `uv run python -c "import ...; print(...)"` or `inspect` to introspect Python source. ✅ Read source files directly or grep for symbols — the code is on disk and can be read without running it.

--- a/template/deployment/{% if is_circuit_python_driver %}helm{% endif %}/templates/deployment.yaml.jinja
+++ b/template/deployment/{% if is_circuit_python_driver %}helm{% endif %}/templates/deployment.yaml.jinja
@@ -115,6 +115,8 @@ spec:
               value: "{{ .Values.env.frontend.BACKEND_PORT }}"
             - name: MDNS_REGISTRATION_PORT
               value: "{{ default .Values.env.frontend.BACKEND_PORT .Values.service.backend.nodePort }}"
+            - name: MDNS_REGISTRATION_FRONTEND_PORT
+              value: "{{ default .Values.env.frontend.FRONTEND_PORT .Values.service.frontend.nodePort }}"
 {{- if regexMatch "^[0-9]" .Values.env.frontend.BACKEND_HOST }} # only set this if it starts with a number (i.e. is an IP address)
             - name: MDNS_REGISTRATION_ADDRESSES
               value: "{{ .Values.env.frontend.BACKEND_HOST }}"

--- a/template/frontend/{% if not deploy_as_executable %}default.conf.template{% endif %}.jinja
+++ b/template/frontend/{% if not deploy_as_executable %}default.conf.template{% endif %}.jinja
@@ -46,10 +46,6 @@
     location /static/swagger/ {
         try_files $uri @proxy;
     }
-    # Pass requests for the OpenAPI spec document to the backend
-    location /openapi.json {
-        try_files $uri @proxy;
-    }
 
     # Named location with shared proxy configuration
     location @proxy {

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -47,7 +47,7 @@ async def lifespan(app: FastAPI):
         except AttributeError:
             port = 4000  # when not invoking from the entrypoint, port may not have been set, so fall back to default dev port
         assert isinstance(port, int), f"Expected port to be int, but got {port} of type {type(port)}"
-        mdns_port = parse_port(env_var_name=MDNS_REGISTRATION_PORT_ENV_VAR_NAME, default=port)
+        mdns_port = {% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}parse_port(env_var_name=MDNS_REGISTRATION_PORT_ENV_VAR_NAME, default=port) # TODO: make parse_port library so can use everywhere{% endraw %}{% else %}{% raw %}int(os.getenv(MDNS_REGISTRATION_PORT_ENV_VAR_NAME, port)){% endraw %}{% endif %}{% raw %}
         await register_driver(azc=azc, port=mdns_port)
         app.state.zc_browser = SimpleBrowser(azc)
         app.state.simulator_config_builder = build_simulator_config

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from typing import override
 {% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
+from backend_api.lib import parse_port
 from fastapi import FastAPI{% endraw %}{% endif %}{% raw %}
 from fastapi import Query
 from fastapi.middleware.cors import CORSMiddleware
@@ -46,7 +47,7 @@ async def lifespan(app: FastAPI):
         except AttributeError:
             port = 4000  # when not invoking from the entrypoint, port may not have been set, so fall back to default dev port
         assert isinstance(port, int), f"Expected port to be int, but got {port} of type {type(port)}"
-        mdns_port = int(os.getenv(MDNS_REGISTRATION_PORT_ENV_VAR_NAME, port))
+        mdns_port = parse_port(env_var_name=MDNS_REGISTRATION_PORT_ENV_VAR_NAME, default=port)
         await register_driver(azc=azc, port=mdns_port)
         app.state.zc_browser = SimpleBrowser(azc)
         app.state.simulator_config_builder = build_simulator_config

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/app_def.py.jinja
@@ -80,6 +80,7 @@ try:
         favicon_url="favicon.ico",
         version=VERSION,
         docs_url="/api-docs",
+        openapi_url="/api/openapi.json",
         static_url="/static/swagger",{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
         lifespan=lifespan,{% endraw %}{% endif %}{% raw %}
     )

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/conftest.py.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/conftest.py.jinja
@@ -5,8 +5,8 @@ from unittest import mock{% endraw %}{% endif %}{% raw %}
 import pytest
 from backend_api import configure_logging
 from backend_api.app_def import app{% endraw %}{% if has_circuit_python_backend_template_been_instantiated %}{% raw %}
-from backend_api.common.mdns import DEVICE_SOURCE_BRIDGE_ALLOW_LIST_ENV_VAR_NAME
-from backend_api.common.rfc_servers_jinja import reset_servers_container{% endraw %}{% endif %}{% raw %}
+from backend_api.common import DEVICE_SOURCE_BRIDGE_ALLOW_LIST_ENV_VAR_NAME
+from backend_api.common import reset_servers_container{% endraw %}{% endif %}{% raw %}
 from fastapi import FastAPI
 
 {% endraw %}{% if configure_python_asyncio %}{% raw %}from .asyncio_fixtures import fail_on_background_task_errors  # noqa: F401 # this is an autouse fixture

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/test_basic_server_functionality.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/test_basic_server_functionality.py
@@ -65,15 +65,16 @@ def test_When_shutdown_route_called__Then_system_exit(mocker: MockerFixture):
 
 def test_openapi_schema(snapshot_json: SnapshotAssertion, mocker: MockerFixture):
     client = TestClient(app)
+    app.openapi_schema = None  # reset cache populated by other tests
     spied_get_openapi = mocker.spy(fast_api_exception_handlers, "get_openapi")
 
-    response = client.get("/openapi.json")
+    response = client.get("/api/openapi.json")
 
     assert response.status_code == codes.OK
     assert response.json() == snapshot_json
     assert spied_get_openapi.call_count == 1
 
-    re_response = client.get("/openapi.json")
+    re_response = client.get("/api/openapi.json")
     assert re_response.status_code == codes.OK
     assert re_response.text == response.text
     assert spied_get_openapi.call_count == 1  # still 1, not reinvoked

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -13,6 +13,8 @@ configure_vcrpy: true
 configure_python_asyncio: true
 
 node_version: 24.11.1
+pnpm_minimum_release_age_exclude: ''
+
 
 python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 8080
 backend_uses_graphql: true
 deploy_as_executable: false
 use_upx_for_executable: false
+install_as_windows_service: false
 is_circuit_python_driver: true
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -13,6 +13,8 @@ configure_vcrpy: false
 configure_python_asyncio: false
 
 node_version: 24.11.1
+pnpm_minimum_release_age_exclude: 'somelib, another-pkg'
+
 
 python_package_registry: AWS CodeArtifact
 aws_central_infrastructure_account_id: 012321432543

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -35,6 +35,7 @@ backend_deployed_port_number: 4001
 backend_uses_graphql: false
 deploy_as_executable: false
 use_upx_for_executable: false
+install_as_windows_service: false
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -13,6 +13,7 @@ configure_vcrpy: false
 configure_python_asyncio: true
 
 node_version: 22.13.0
+pnpm_minimum_release_age_exclude: 'ooga-chaka,@blarg/*'
 
 python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053

--- a/tests/copier_data/data3.yaml
+++ b/tests/copier_data/data3.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 4000
 backend_uses_graphql: false
 deploy_as_executable: false
 use_upx_for_executable: false
+install_as_windows_service: false
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: true

--- a/tests/copier_data/data4.yaml
+++ b/tests/copier_data/data4.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 4020
 backend_uses_graphql: false
 deploy_as_executable: true
 use_upx_for_executable: true
+install_as_windows_service: true
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false

--- a/tests/copier_data/data4.yaml
+++ b/tests/copier_data/data4.yaml
@@ -13,6 +13,7 @@ configure_vcrpy: true
 configure_python_asyncio: false
 
 node_version: 22.13.0
+pnpm_minimum_release_age_exclude: ''
 
 python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053

--- a/tests/copier_data/data5.yaml
+++ b/tests/copier_data/data5.yaml
@@ -30,6 +30,7 @@ backend_deployed_port_number: 5050
 backend_uses_graphql: false
 deploy_as_executable: true
 use_upx_for_executable: false
+install_as_windows_service: false
 is_circuit_python_driver: false
 has_circuit_python_backend_template_been_instantiated: false
 install_gcc_in_backend_container_build_phase: false

--- a/tests/copier_data/data5.yaml
+++ b/tests/copier_data/data5.yaml
@@ -13,6 +13,7 @@ configure_vcrpy: false
 configure_python_asyncio: true
 
 node_version: 24.11.1
+pnpm_minimum_release_age_exclude: 'some-repo,  all-the-things*'
 
 python_package_registry: PyPI
 aws_identity_center_id: d-9145c20053

--- a/tests/unit/copier_tasks/helpers.py
+++ b/tests/unit/copier_tasks/helpers.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_copier_task(
+    script_path: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- these are our own scripts
+        [sys.executable, str(script_path), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )

--- a/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
+++ b/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
@@ -1,0 +1,101 @@
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _PROJECT_ROOT / "src" / "copier_tasks" / "ensure_pnpm_minimum_release_age_exclude.py"
+
+
+def _pkg() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+def _scoped_pkg() -> str:
+    return f"@{uuid.uuid4().hex[:4]}/{uuid.uuid4().hex[:6]}"
+
+
+class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
+    def _run_script(self, *, patterns: str, target_file: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 -- this is our own script
+            [
+                sys.executable,
+                str(_SCRIPT_PATH),
+                "--patterns",
+                patterns,
+                "--target-file",
+                str(target_file),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_When_target_file_does_not_exist__Then_exits_0_and_reports_skipping(self, tmp_path: Path) -> None:
+        pkg = _pkg()
+        nonexistent = tmp_path / "pnpm-workspace.yaml"
+
+        result = self._run_script(patterns=pkg, target_file=nonexistent)
+
+        assert result.returncode == 0
+        assert "not found" in result.stdout
+
+    def test_When_section_present_with_missing_pattern__Then_inserts_missing_entry(self, tmp_path: Path) -> None:
+        expected_num_excludes = 2
+        existing = _pkg()
+        new = _pkg()
+        workspace = tmp_path / "pnpm-workspace.yaml"
+        _ = workspace.write_text(f'minimumReleaseAgeExclude:\n  - "{existing}"\n', encoding="utf-8")
+
+        result = self._run_script(patterns=f"{existing}, {new}", target_file=workspace)
+
+        raw = workspace.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw)
+        assert result.returncode == 0
+        assert len(parsed["minimumReleaseAgeExclude"]) == expected_num_excludes
+        assert existing in parsed["minimumReleaseAgeExclude"]
+        assert new in parsed["minimumReleaseAgeExclude"]
+        assert f'  - "{new}"' in raw
+
+    def test_When_all_patterns_already_present__Then_file_unchanged_and_no_output(self, tmp_path: Path) -> None:
+        pkg_a = _pkg()
+        scoped = _scoped_pkg()
+        workspace = tmp_path / "pnpm-workspace.yaml"
+        original = f'minimumReleaseAgeExclude:\n  - "{pkg_a}"\n  - "{scoped}"\n'
+        _ = workspace.write_text(original, encoding="utf-8")
+
+        result = self._run_script(patterns=f"{pkg_a}, {scoped}", target_file=workspace)
+
+        assert result.returncode == 0
+        assert workspace.read_text(encoding="utf-8") == original
+        assert result.stdout == ""
+
+    def test_When_pattern_present_unquoted__Then_no_duplicate_added(self, tmp_path: Path) -> None:
+        pkg = _pkg()
+        workspace = tmp_path / "pnpm-workspace.yaml"
+        original = f"minimumReleaseAgeExclude:\n  - {pkg}\n"
+        _ = workspace.write_text(original, encoding="utf-8")
+
+        result = self._run_script(patterns=pkg, target_file=workspace)
+
+        assert result.returncode == 0
+        assert workspace.read_text(encoding="utf-8") == original
+        assert result.stdout == ""
+
+    def test_When_section_absent__Then_appends_block_with_double_quoted_entries(self, tmp_path: Path) -> None:
+        scoped = _scoped_pkg()
+        plain = _pkg()
+        workspace = tmp_path / "pnpm-workspace.yaml"
+        _ = workspace.write_text("packages:\n  - frontend\n", encoding="utf-8")
+
+        result = self._run_script(patterns=f"{scoped}, {plain}", target_file=workspace)
+
+        raw = workspace.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw)
+        assert result.returncode == 0
+        assert parsed["minimumReleaseAgeExclude"] == [scoped, plain]
+        assert parsed["packages"] == ["frontend"]
+        assert f'  - "{scoped}"' in raw
+        assert f'  - "{plain}"' in raw

--- a/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
+++ b/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
@@ -1,9 +1,10 @@
 import subprocess
-import sys
 import uuid
 from pathlib import Path
 
 import yaml
+
+from .helpers import run_copier_task
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT_PATH = _PROJECT_ROOT / "src" / "copier_tasks" / "ensure_pnpm_minimum_release_age_exclude.py"
@@ -18,84 +19,50 @@ def _scoped_pkg() -> str:
 
 
 class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
-    def _run_script(self, *, patterns: str, target_file: Path) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(  # noqa: S603 -- this is our own script
-            [
-                sys.executable,
-                str(_SCRIPT_PATH),
-                "--patterns",
-                patterns,
-                "--target-file",
-                str(target_file),
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+    def _run_script(
+        self,
+        *,
+        patterns: str,
+        target_dir: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return run_copier_task(_SCRIPT_PATH, "--patterns", patterns, "--target-dir", str(target_dir), env=env)
 
-    def test_When_target_file_does_not_exist__Then_exits_0_and_reports_skipping(self, tmp_path: Path) -> None:
-        pkg = _pkg()
-        nonexistent = tmp_path / "pnpm-workspace.yaml"
+    def test_When_pnpm_not_on_path__Then_exits_nonzero_with_error(self, tmp_path: Path) -> None:
+        _ = (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - frontend\n", encoding="utf-8")
 
-        result = self._run_script(patterns=pkg, target_file=nonexistent)
+        result = self._run_script(patterns=_pkg(), target_dir=tmp_path, env={"PATH": ""})
+
+        assert result.returncode != 0
+        assert "pnpm" in result.stdout
+
+    def test_When_target_dir_has_no_workspace_file__Then_exits_0_and_reports_skipping(self, tmp_path: Path) -> None:
+        result = self._run_script(patterns=_pkg(), target_dir=tmp_path)
 
         assert result.returncode == 0
         assert "not found" in result.stdout
+        assert not (tmp_path / "pnpm-workspace.yaml").exists()
 
-    def test_When_section_present_with_missing_pattern__Then_inserts_missing_entry(self, tmp_path: Path) -> None:
-        expected_num_excludes = 2
+    def test_When_workspace_has_existing_patterns__Then_new_patterns_appended(self, tmp_path: Path) -> None:
         existing = _pkg()
         new = _pkg()
         workspace = tmp_path / "pnpm-workspace.yaml"
-        _ = workspace.write_text(f'minimumReleaseAgeExclude:\n  - "{existing}"\n', encoding="utf-8")
+        _ = workspace.write_text(f"minimumReleaseAgeExclude: {existing}\n", encoding="utf-8")
 
-        result = self._run_script(patterns=f"{existing}, {new}", target_file=workspace)
-
-        raw = workspace.read_text(encoding="utf-8")
-        parsed = yaml.safe_load(raw)
-        assert result.returncode == 0
-        assert len(parsed["minimumReleaseAgeExclude"]) == expected_num_excludes
-        assert existing in parsed["minimumReleaseAgeExclude"]
-        assert new in parsed["minimumReleaseAgeExclude"]
-        assert f'  - "{new}"' in raw
-
-    def test_When_all_patterns_already_present__Then_file_unchanged_and_no_output(self, tmp_path: Path) -> None:
-        pkg_a = _pkg()
-        scoped = _scoped_pkg()
-        workspace = tmp_path / "pnpm-workspace.yaml"
-        original = f'minimumReleaseAgeExclude:\n  - "{pkg_a}"\n  - "{scoped}"\n'
-        _ = workspace.write_text(original, encoding="utf-8")
-
-        result = self._run_script(patterns=f"{pkg_a}, {scoped}", target_file=workspace)
+        result = self._run_script(patterns=new, target_dir=tmp_path)
 
         assert result.returncode == 0
-        assert workspace.read_text(encoding="utf-8") == original
-        assert result.stdout == ""
+        parsed = yaml.safe_load(workspace.read_text(encoding="utf-8"))
+        assert parsed["minimumReleaseAgeExclude"] == f"{existing},{new}"
 
-    def test_When_pattern_present_unquoted__Then_no_duplicate_added(self, tmp_path: Path) -> None:
-        pkg = _pkg()
-        workspace = tmp_path / "pnpm-workspace.yaml"
-        original = f"minimumReleaseAgeExclude:\n  - {pkg}\n"
-        _ = workspace.write_text(original, encoding="utf-8")
-
-        result = self._run_script(patterns=pkg, target_file=workspace)
-
-        assert result.returncode == 0
-        assert workspace.read_text(encoding="utf-8") == original
-        assert result.stdout == ""
-
-    def test_When_section_absent__Then_appends_block_with_double_quoted_entries(self, tmp_path: Path) -> None:
+    def test_When_patterns_provided__Then_sets_value_in_workspace(self, tmp_path: Path) -> None:
         scoped = _scoped_pkg()
         plain = _pkg()
         workspace = tmp_path / "pnpm-workspace.yaml"
         _ = workspace.write_text("packages:\n  - frontend\n", encoding="utf-8")
 
-        result = self._run_script(patterns=f"{scoped}, {plain}", target_file=workspace)
+        result = self._run_script(patterns=f"{scoped}, {plain}", target_dir=tmp_path)
 
-        raw = workspace.read_text(encoding="utf-8")
-        parsed = yaml.safe_load(raw)
         assert result.returncode == 0
-        assert parsed["minimumReleaseAgeExclude"] == [scoped, plain]
-        assert parsed["packages"] == ["frontend"]
-        assert f'  - "{scoped}"' in raw
-        assert f'  - "{plain}"' in raw
+        parsed = yaml.safe_load(workspace.read_text(encoding="utf-8"))
+        assert parsed["minimumReleaseAgeExclude"] == f"{scoped},{plain}"

--- a/tests/unit/copier_tasks/test_remove_precommit_hooks.py
+++ b/tests/unit/copier_tasks/test_remove_precommit_hooks.py
@@ -1,8 +1,9 @@
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
+
+from .helpers import run_copier_task
 
 _EXIT_CODE_INVALID_REGEX = 2
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
@@ -11,19 +12,7 @@ _SCRIPT_PATH = _PROJECT_ROOT / "src" / "copier_tasks" / "remove_precommit_hooks.
 
 class TestRemovePrecommitHooksViaSubprocess:
     def _run_script(self, *, hook_id_regex: str, target_file: Path) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(  # noqa: S603 # this is our own script
-            [
-                sys.executable,
-                str(_SCRIPT_PATH),
-                "--hook-id-regex",
-                hook_id_regex,
-                "--target-file",
-                str(target_file),
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
+        return run_copier_task(_SCRIPT_PATH, "--hook-id-regex", hook_id_regex, "--target-file", str(target_file))
 
     def test_When_run_with_matching_hook__Then_hook_removed(self, tmp_path: Path) -> None:
         source_config = _PROJECT_ROOT / ".pre-commit-config.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
-    { name = "ty", specifier = ">=0.0.37" },
+    { name = "ty", specifier = ">=0.0.38" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "copier"
-version = "9.15.0"
+version = "9.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
@@ -39,9 +39,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "questionary" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/ec/e67bcf9b867a47dd8cf98e8c8e27ee8cf638633f72c535372ce5e30ade80/copier-9.15.0.tar.gz", hash = "sha256:57b951d9f63b6b9d6ce3907fb1bd4672f60e2819a42393b971122d480059383f", size = 635532, upload-time = "2026-04-30T12:52:56.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/77/1b96b1b174e576155a8ce7361ecbf5e3cf8c679cec49acf6f4adf3f68f39/copier-9.15.1.tar.gz", hash = "sha256:0fceec8c27d80a0573809837472f4aaee48b90930f473f9674847a02a2ad7da5", size = 639650, upload-time = "2026-05-13T13:46:09.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/ba/fc20faf5b2bb04615fa906f8daecfe896e6f7a56b34debd93c4a4d63e6e5/copier-9.15.0-py3-none-any.whl", hash = "sha256:0f59c2ea36df42f3ded85c091c3f1e2c8d3814b537504f0abc8c2e508f7e013d", size = 62747, upload-time = "2026-04-30T12:52:54.443Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/12/bbce9472f489cb5c4c23b0d13e5c59c37c1aab11b7ac637dfe6bbdccebe7/copier-9.15.1-py3-none-any.whl", hash = "sha256:040164686e45e7a841dcd4ae39b01e27093ff91242be3563cae883c4e24c55cc", size = 62937, upload-time = "2026-05-13T13:46:08.166Z" },
 ]
 
 [[package]]
@@ -60,13 +60,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "copier", specifier = "==9.15.0" },
+    { name = "copier", specifier = "==9.15.1" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-randomly", specifier = ">=4.1.0" },
-    { name = "ty", specifier = ">=0.0.34" },
+    { name = "ty", specifier = ">=0.0.37" },
 ]
 
 [[package]]
@@ -498,26 +498,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.34"
+version = "0.0.38"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/3b/45be6b37d5060d6917bf7f1f234c00d360fc5f8b7486f8a96af640e25661/ty-0.0.38.tar.gz", hash = "sha256:fbc8d47f7630457669ab41e333dc093897fdb7ead1ffc94dcf8f30b5d39aa56d", size = 5681218, upload-time = "2026-05-20T00:15:32.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
-    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
-    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
-    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
-    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
+    { url = "https://files.pythonhosted.org/packages/54/43/ea9b4e57d6a266670dbe34858e92f6093ca054ad1b48f1c82580a72340fb/ty-0.0.38-py3-none-linux_armv6l.whl", hash = "sha256:3501dcf44ca03f813f9cb4fabfdf601adc0ac1337c411405b470530679e37a45", size = 11289326, upload-time = "2026-05-20T00:14:52.371Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ff/24e2f623a1c6b5f5ccf8bf82fccd937033c6a7dba57a4028c7f41270fa4a/ty-0.0.38-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b34b4094b76252c3e8c90762cdd5e8a9f1101534484745ff4b480f71eb38ac2e", size = 11063047, upload-time = "2026-05-20T00:14:42.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/41/4f0d910f0acbd20b358eda80a5cd6a8361d27ff5b8e87ab559d3f69f125e/ty-0.0.38-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c518ad33a877677365baab2e21d82cf59ffee789203a15a143f5179ee5a1d3f8", size = 10494436, upload-time = "2026-05-20T00:15:24.425Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d8/da06833422082aa98b169a391f9197e2d73865e96c90b6979ac886b890a2/ty-0.0.38-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9238494722303eccddc6a27eb647948b694eecd6b974910d13b9e6cd46bbeb6a", size = 11000992, upload-time = "2026-05-20T00:14:58.368Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f7/e1172197fb827e6410ca3eb0dc68ef2789f3c70683696f2a0ce5c90764fd/ty-0.0.38-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31d91d7336c5d51bf822ac0df512f300584ca4dcca041fc6a6d7df03a8ddbb31", size = 11058583, upload-time = "2026-05-20T00:15:11.314Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/61/7fbaf0c05981e006a8804287819c574dff90a6bf8e96efad7226be0700aa/ty-0.0.38-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65165879814993450710b9349791e4898c65e36b1e14eec554884c06a2f20ff1", size = 11531036, upload-time = "2026-05-20T00:15:14.62Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e3/47c0c64e401d50f925df3e52479d4e7626754b2a9e38201d142fdacd6252/ty-0.0.38-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d61868b8d1c4033bf8088191de953fed245c2f9e1bb9d2d53e5699170b0924c", size = 12129991, upload-time = "2026-05-20T00:14:39.475Z" },
+    { url = "https://files.pythonhosted.org/packages/90/99/2f452d02901bcd7f1b109cf5b848727ce37f372c3406143aa52d1305d40e/ty-0.0.38-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8f9a9175548c98dbff7707865738c07c2b1f8e07a09b8c68101baebb5dac59a4", size = 11756167, upload-time = "2026-05-20T00:15:27.526Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/c7e14d111c813e1a20b82e944f1c997c4631a2bb710eaa64fb6b26835e13/ty-0.0.38-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:375d3a964c6b4aea2e9237fdb5eb9ed03dc43088986a94209a28a4ea3b62001c", size = 11637099, upload-time = "2026-05-20T00:15:21.261Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/ab02659dd1ed62898db7db4d37f9937c80854dd45e95093fa0fe10328d82/ty-0.0.38-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:cdfd547782c45267aa0b52abad31bd406bf4768c264532ef9e2360cd3c6ce048", size = 11813583, upload-time = "2026-05-20T00:14:45.875Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/57/bd1b5ebf4e71a4295484afac0202df1740b0807762b86744b1bef4534984/ty-0.0.38-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:858bc675b75626470abe4e6c3b3934b853642b04f2ac4d7139fcefea3b48b213", size = 10975405, upload-time = "2026-05-20T00:15:30.354Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/55/0305c78711bbd23922cf291996a08ef9544f4179da98e9a75c14e608f379/ty-0.0.38-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:54be4f00432870da42cd74fe145a3362fd248e22d032c74bd807cb45bf068f94", size = 11097551, upload-time = "2026-05-20T00:14:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4f/7effe7f9a6ac9719eb7234172c01739c5f888bb47f9acc2ea8da1f4afed3/ty-0.0.38-py3-none-musllinux_1_2_i686.whl", hash = "sha256:494af66a76a86dbf16a3003d3b63b03484aa4c7489dfe11f3ee5413b98b22d60", size = 11214391, upload-time = "2026-05-20T00:15:18.094Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/d9fdfec3a74a6ad0209fa5e7113ae29d4f457d0651cfbb813b4c6563e0d4/ty-0.0.38-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3d92527c4be78a5ce6d32e8bb0aa2a6988d4076eddf1294e56fdaf06d1a98e7e", size = 11730871, upload-time = "2026-05-20T00:14:49.219Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4a/beefade12d109b4f7793d61b04b4478b1ad4d1465a719e7ff55b2d42461a/ty-0.0.38-py3-none-win32.whl", hash = "sha256:36fc5dd5dc09207ff3004b1560a79a3fb8d12456daeec914a7b802a918da654c", size = 10548583, upload-time = "2026-05-20T00:15:07.892Z" },
+    { url = "https://files.pythonhosted.org/packages/15/64/941b205e2e46cc2297c245c64aa7691410b7454fa4d07a6cb3cf59487833/ty-0.0.38-py3-none-win_amd64.whl", hash = "sha256:eef0a8956ba14514076b1a963d13eb32986d9ebad7f0527b3cc01cb68bf35147", size = 11650542, upload-time = "2026-05-20T00:15:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/59/02/c1c4f9ec4b94d95190636fa13f79c32f65165fbe3a0503882d4df164d2ac/ty-0.0.38-py3-none-win_arm64.whl", hash = "sha256:79abfc8658a026c30b1c955613437dab3ef4b12feca56a3e6df50903cc39e07f", size = 11010307, upload-time = "2026-05-20T00:15:04.567Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why is this change necessary?
`pnpm dev` mode can't access things in the backend easily unless they're under `/api`


## How does this change address the issue?
Moves the openapi.json file there


## What side effects does this change have?
It's a breaking change, but I think we've dealt with it everywhere


## How is this change tested?
Many downstream repos


## Other
Pulls in upstream updates, also makes some tweaks for circuit python drivers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for excluding packages from pnpm's minimum release age constraint.
  * Added Windows service installation option for deployments.
  * Added explicit OpenAPI schema endpoint configuration.
  * Enhanced API documentation routing for Swagger static files.

* **Chores**
  * Updated development tool versions: pnpm, copier, ty, uvicorn, and related dependencies.
  * Updated CI workflow to explicitly specify Node version.
  * Added CI validation check for template configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->