### PR TITLE
Better debug nuxt common bump

### DIFF
--- a/extensions/context.py
+++ b/extensions/context.py
@@ -86,7 +86,7 @@ class ContextUpdater(ContextHook):
         context["vue_eslint_parser_version"] = "^10.4.0"
         context["happy_dom_version"] = "^20.9.0"
         context["node_kiota_bundle_version"] = "1.0.0-preview.100"
-        context["labsync_nuxt_common_version"] = "^0.1.0"
+        context["labsync_nuxt_common_version"] = "^0.1.1"
         context["tanstack_vue_table_version"] = "^8.21.3"
         context["unplugin_auto_import_version"] = "^21.0.0"
 

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -68,6 +68,7 @@ docs/_build
 tests/**/snapshots/*_actual.png
 tests/**/snapshots/*_diff.png
 pytest.log
+test-screenshots
 
 # test coverage
 tests/__coverage__

--- a/template/frontend/tests/setup/app.ts
+++ b/template/frontend/tests/setup/app.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs";
+import path from "node:path";
 import type { Browser, Page } from "playwright";
 import { chromium } from "playwright";
-import { afterAll, beforeAll, beforeEach } from "vitest";
+import { afterAll, beforeAll, beforeEach, onTestFailed } from "vitest";
 
 const isE2E = process.env.USE_DOCKER_COMPOSE_FOR_VITEST_E2E || process.env.USE_BUILT_BACKEND_FOR_VITEST_E2E;
 let browser: Browser;
@@ -10,8 +12,27 @@ if (isE2E) {
   beforeAll(async () => {
     browser = await chromium.launch(); // headless by default
   }, 40 * 1000); // increase timeout to allow application to start
-  beforeEach(async () => {
+  beforeEach(async (ctx) => {
     page = await browser.newPage();
+
+    page.on("console", (msg) => {
+      console.log(`[browser:${msg.type()}]`, msg.text());
+    });
+    page.on("pageerror", (err) => {
+      console.error("[browser:pageerror]", err.message);
+    });
+    page.on("requestfailed", (req) => {
+      console.error("[browser:requestfailed]", req.url(), req.failure()?.errorText);
+    });
+
+    onTestFailed(async () => {
+      const screenshotDir = path.resolve("./test-results");
+      fs.mkdirSync(screenshotDir, { recursive: true });
+      const safeName = ctx.task.name.replace(/[^\w-]/g, "_");
+      const screenshotPath = path.join(screenshotDir, `${safeName}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+      console.log(`[debug] screenshot saved: ${screenshotPath}`);
+    });
   });
   afterAll(async () => {
     await browser.close();

--- a/template/frontend/tests/setup/app.ts
+++ b/template/frontend/tests/setup/app.ts
@@ -26,7 +26,7 @@ if (isE2E) {
     });
 
     onTestFailed(async () => {
-      const screenshotDir = path.resolve("./test-results");
+      const screenshotDir = path.resolve("./test-screenshots");
       fs.mkdirSync(screenshotDir, { recursive: true });
       const safeName = ctx.task.name.replace(/[^\w-]/g, "_");
       const screenshotPath = path.join(screenshotDir, `${safeName}.png`);


### PR DESCRIPTION
## Link to Issue or Message thread
Related to this https://github.com/lab-sync/copier-circuit-python-device-driver-frontend/pull/3


## Why is this change necessary?
Need to have latest nuxt-common version downstream to fix issues with e2e tests. 


## How does this change address the issue?
While trying to figure out issues with e2e tests had to do some debugging. Backporting that into the template. Now it'll console log anything that the app logs to console or if there are page/request errors. And if the test fails it will take a screenshot and save it.


## What side effects does this change have?
N/A


## How is this change tested?
Downstream 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to version 0.1.1

* **Tests**
  * Enhanced E2E test suite with automatic screenshot capture on test failures and improved logging for browser output and network issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LabAutomationAndScreening/copier-nuxt-python-intranet-app/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->