### PR TITLE
Better handling of logging in CI

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/tests/e2e/app_bootup.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/e2e/app_bootup.py
@@ -3,8 +3,11 @@ import logging
 import os
 import socket
 import subprocess
+import sys
+import threading
 import time
 from pathlib import Path
+from typing import IO
 
 import httpx
 
@@ -15,9 +18,11 @@ from .jinja_constants import ApplicationBootupModes
 
 logger = logging.getLogger(__name__)
 
+IS_WINDOWS = os.name == "nt"
 DEFAULT_COMPOSE_FILE = Path(__file__).parent.parent.parent.parent / "docker-compose.yaml"
 EXE_DIR_PATH = Path(__file__).parent.parent.parent / "dist" / APP_NAME
-EXE_FILE_NAME = APP_NAME + (".exe" if os.name == "nt" else "")
+E2E_BACKEND_LOG_DIR = Path(__file__).parent.parent.parent / "dist" / "e2e-backend-logs"
+EXE_FILE_NAME = APP_NAME + (".exe" if IS_WINDOWS else "")
 EXE_FILE_PATH = EXE_DIR_PATH / EXE_FILE_NAME
 
 
@@ -239,6 +244,7 @@ def start_exe(*, port: int, env: dict[str, str] | None = None) -> subprocess.Pop
         env = (  # by default, pass in any environmental variables configured during the test setup process
             os.environ.copy()
         )
+    E2E_BACKEND_LOG_DIR.mkdir(parents=True, exist_ok=True)
     process = subprocess.Popen(  # noqa: S603 # we trust this input
         [
             str(EXE_FILE_PATH),
@@ -246,11 +252,25 @@ def start_exe(*, port: int, env: dict[str, str] | None = None) -> subprocess.Pop
             str(port),
             "--host",
             "0.0.0.0",  # noqa: S104 # until we get Windows CI fully figured out, we're just binding everything
+            "--log-folder",  # the backend also writes its own structured JSON log here; CI uploads it on failure
+            str(E2E_BACKEND_LOG_DIR),
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
     )
+
+    # Both pipes MUST be drained: an unread PIPE fills its OS buffer and blocks the backend (deadlocks readily on
+    # Windows). We mirror each line to our own stream so the backend's output stays visible in the CI job log.
+    def _drain(stream: IO[bytes] | None, *, mirror: IO[str]) -> None:
+        assert stream is not None
+        for raw_line in stream:
+            _ = mirror.write(raw_line.decode("utf-8", errors="replace"))
+            mirror.flush()
+
+    _ = threading.Thread(target=_drain, args=(process.stdout,), kwargs={"mirror": sys.stdout}, daemon=True).start()
+    _ = threading.Thread(target=_drain, args=(process.stderr,), kwargs={"mirror": sys.stderr}, daemon=True).start()
+
     wait_for_backend_to_be_healthy(port=port)
     return process
 

--- a/template/{% if has_backend %}backend{% endif %}/tests/{% if install_as_windows_service %}windows_service{% endif %}/test_service_lifecycle.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/{% if install_as_windows_service %}windows_service{% endif %}/test_service_lifecycle.py
@@ -57,10 +57,10 @@ def _install_service(*, port: int, log_folder: Path, extra_runtime_args: Sequenc
         "--",
         "--port",
         str(port),
-        "--host",
-        "0.0.0.0",  # noqa: S104 # match e2e pattern: bind everything until Windows CI networking sorted out
         "--log-folder",
         str(log_folder),
+        "--host",
+        "0.0.0.0",  # noqa: S104 # match e2e pattern: bind everything until Windows CI networking sorted out
         *extra_runtime_args,
     )
 
@@ -236,10 +236,10 @@ def test_When_install_with_startup_option_before_subcommand__Then_service_regist
             "--",
             "--port",
             str(port),
-            "--host",
-            "0.0.0.0",  # noqa: S104 # match e2e pattern
             "--log-folder",
             str(log_folder),
+            "--host",
+            "0.0.0.0",  # noqa: S104 # match e2e pattern
         )
 
         result = _run_sc("qc", APP_NAME, check=True)


### PR DESCRIPTION
## Why is this change necessary?
On Windows there's a smaller buffer than Linux, and it needs to be drained.

Also good to log to an explicit folder in CI so that any CI jobs can decide to upload it if needed (backend E2E CI for executables is still not in the template because it's a bit repo-specific)



## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos using docker and using windows EXE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved backend startup logging with enhanced output stream handling for better cross-platform diagnostics.
  * Optimized Windows service installation testing with consistent CLI argument ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->