### PR TITLE
Always regen VRT snapshots if requested

### DIFF
--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -19,7 +19,7 @@
     "test-compiled": "dotenv -v NUXT_DISABLE_OPTIMIZE_DEPS=1 -- vitest run --project=compiled",
     "test-compiled-dev": "dotenv -v NUXT_DISABLE_OPTIMIZE_DEPS=1 -v NUXT_TEST_DEV=1 -- vitest run --project=compiled",
     "test-e2e": "{% endraw %}{% if not deploy_as_executable %}{% raw %}[ \"${CI}\" = \"true\" ] || docker compose --file=../docker-compose.yaml build && dotenv -v USE_DOCKER_COMPOSE_FOR_E2E=1{% endraw %}{% else %}{% raw %}dotenv -v USE_BUILT_BACKEND_FOR_E2E=1{% endraw %}{% endif %}{% raw %} -- playwright test",
-    "test-e2e:update-snapshots": "{% endraw %}{% if not deploy_as_executable %}{% raw %}[ \"${CI}\" = \"true\" ] || docker compose --file=../docker-compose.yaml build && dotenv -v USE_DOCKER_COMPOSE_FOR_E2E=1{% endraw %}{% else %}{% raw %}dotenv -v USE_BUILT_BACKEND_FOR_E2E=1{% endraw %}{% endif %}{% raw %} -- playwright test --update-snapshots",
+    "test-e2e:update-snapshots": "{% endraw %}{% if not deploy_as_executable %}{% raw %}[ \"${CI}\" = \"true\" ] || docker compose --file=../docker-compose.yaml build && dotenv -v USE_DOCKER_COMPOSE_FOR_E2E=1{% endraw %}{% else %}{% raw %}dotenv -v USE_BUILT_BACKEND_FOR_E2E=1{% endraw %}{% endif %}{% raw %} -- playwright test --update-snapshots all",
     "test-compiled:watch": "dotenv -v NUXT_DISABLE_OPTIMIZE_DEPS=1 -- vitest --project=compiled",
     "test-compiled-dev:watch": "dotenv -v NUXT_DISABLE_OPTIMIZE_DEPS=1 -v NUXT_TEST_DEV=1 -- vitest --project=compiled"{% endraw %}{% if frontend_uses_graphql %}{% raw %},
     "codegen": "graphql-codegen --config codegen.ts"{% endraw %}{% endif %}{% raw %}


### PR DESCRIPTION
## Link to Issue or Message thread
https://github.com/microsoft/playwright/issues/37009


## Why is this change necessary?
Similar to the issue above, we had an issue where the ratio was high enough to not update snapshots where some spacing was important causing debugging into why this would be the behavior.  


## How does this change address the issue?
Now when you update snapshots that is what happens always so that any change is now captured. 


## What side effects does this change have?
N/A


## How is this change tested?
Downstream on repo that had some important whitespace issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E test snapshot update behavior to use expanded snapshot capture. This improves snapshot management during test maintenance and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->