### PR TITLE
update k3ds version to fix broken builds

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.130-1-g65897e1
+_commit: v0.0.131
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.130
+_commit: v0.0.130-1-g65897e1
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -108,6 +108,7 @@ class ContextUpdater(ContextHook):
         context["gha_pypi_publish"] = "v1.14.0"
         context["gha_sleep"] = "v2.0.3"
         context["gha_absaoss_k3d"] = "v2.4.0"
+        context["k3d_version"] = "v5.5.0"
         context["gha_azure_setup_helm"] = "v5.0.0"
         context["helm_version"] = "v3.18.3"
         context["gha_azure_setup_kubectl"] = "v5.1.0"

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -308,6 +308,7 @@ jobs:
         uses: AbsaOSS/k3d-action@{% endraw %}{{ gha_absaoss_k3d }}{% raw %}
         with:
           cluster-name: e2e
+          k3d-version: {% endraw %}{{ k3d_version }}{% raw %}
           args: >-
             --agents 0
             --port {% endraw %}{{ frontend_nodeport_number }}{% raw %}:{% endraw %}{{ frontend_nodeport_number }}{% raw %}@server:0


### PR DESCRIPTION
## Link to Issue or Message thread
CI build failures in downstream repos


## Why is this change necessary?
k3ds install script is now checking for checksums.txt. The version that is pinned in the action 5.4.6 does not have that file. Thus resulting in the install script failing with a 404.


## How does this change address the issue?
Updates the action to use a newer version of k3ds that has checksum.txt. Specifically picked the closest version that had checksums vs going to latest since the action calls this out

> Implementation of additional features brings complexity and sometimes it may happen that external dependencies get broken. To prevent potential issues, k3d version is fixed according to the mapping below.

So this felt like the safest choice for now.


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


## Other
We should probably test and see if latest k3ds could work or look for a new action altogether this one was last changed in 2023. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated k3d version to v5.5.0 in CI/CD infrastructure. The testing pipeline now explicitly specifies the k3d version used for end-to-end testing, ensuring consistent cluster creation across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->