### PR TITLE
Separate docker compose helpers for frontend E2E

### DIFF
--- a/template/frontend/tests/e2e/compose.ts
+++ b/template/frontend/tests/e2e/compose.ts
@@ -25,7 +25,17 @@ function isComposePsService(value: unknown): value is ComposePsService {
 export function composeUp({ composeFile, services = [] }: { composeFile: string; services?: string[] }): void {
   execFileSync(
     "docker",
-    ["compose", "--file", composeFile, "up", "--detach", "--force-recreate", "--renew-anon-volumes", "--remove-orphans", ...services],
+    [
+      "compose",
+      "--file",
+      composeFile,
+      "up",
+      "--detach",
+      "--force-recreate",
+      "--renew-anon-volumes",
+      "--remove-orphans",
+      ...services,
+    ],
     { stdio: "inherit" },
   );
 }

--- a/template/frontend/tests/e2e/compose.ts
+++ b/template/frontend/tests/e2e/compose.ts
@@ -36,12 +36,15 @@ export function composeUp({ composeFile, services = [] }: { composeFile: string;
       "--remove-orphans",
       ...services,
     ],
-    { stdio: "inherit" },
+    { stdio: "inherit", timeout: 120000 },
   );
 }
 
 export function composeDown({ composeFile }: { composeFile: string }): void {
-  execFileSync("docker", ["compose", "--file", composeFile, "down", "--volumes"], { stdio: "inherit" });
+  execFileSync("docker", ["compose", "--file", composeFile, "down", "--volumes"], {
+    stdio: "inherit",
+    timeout: 120000,
+  });
 }
 
 export async function waitForComposeHealthy({

--- a/template/frontend/tests/e2e/compose.ts
+++ b/template/frontend/tests/e2e/compose.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 interface ComposePsService {
   Service: string;
@@ -23,15 +23,15 @@ function isComposePsService(value: unknown): value is ComposePsService {
 }
 
 export function composeUp({ composeFile, services = [] }: { composeFile: string; services?: string[] }): void {
-  const serviceArgs = services.length > 0 ? ` ${services.join(" ")}` : "";
-  execSync(
-    `docker compose --file="${composeFile}" up --detach --force-recreate --renew-anon-volumes --remove-orphans${serviceArgs}`,
+  execFileSync(
+    "docker",
+    ["compose", "--file", composeFile, "up", "--detach", "--force-recreate", "--renew-anon-volumes", "--remove-orphans", ...services],
     { stdio: "inherit" },
   );
 }
 
 export function composeDown({ composeFile }: { composeFile: string }): void {
-  execSync(`docker compose --file="${composeFile}" down --volumes`, { stdio: "inherit" });
+  execFileSync("docker", ["compose", "--file", composeFile, "down", "--volumes"], { stdio: "inherit" });
 }
 
 export async function waitForComposeHealthy({
@@ -44,7 +44,7 @@ export async function waitForComposeHealthy({
   retryDelayMs?: number;
 }): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const stdout = execSync(`docker compose --file="${composeFile}" ps --format json`, {
+    const stdout = execFileSync("docker", ["compose", "--file", composeFile, "ps", "--format", "json"], {
       encoding: "utf-8",
       timeout: 10000,
     });

--- a/template/frontend/tests/e2e/compose.ts
+++ b/template/frontend/tests/e2e/compose.ts
@@ -1,0 +1,70 @@
+import { execSync } from "node:child_process";
+
+interface ComposePsService {
+  Service: string;
+  Health: string;
+  State: string;
+}
+
+function isComposePsService(value: unknown): value is ComposePsService {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("Service" in value) || typeof value.Service !== "string") {
+    return false;
+  }
+  if (!("Health" in value) || typeof value.Health !== "string") {
+    return false;
+  }
+  if (!("State" in value) || typeof value.State !== "string") {
+    return false;
+  }
+  return true;
+}
+
+export function composeUp({ composeFile, services = [] }: { composeFile: string; services?: string[] }): void {
+  const serviceArgs = services.length > 0 ? ` ${services.join(" ")}` : "";
+  execSync(
+    `docker compose --file="${composeFile}" up --detach --force-recreate --renew-anon-volumes --remove-orphans${serviceArgs}`,
+    { stdio: "inherit" },
+  );
+}
+
+export function composeDown({ composeFile }: { composeFile: string }): void {
+  execSync(`docker compose --file="${composeFile}" down --volumes`, { stdio: "inherit" });
+}
+
+export async function waitForComposeHealthy({
+  composeFile,
+  maxAttempts = 30,
+  retryDelayMs = 2000,
+}: {
+  composeFile: string;
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}): Promise<void> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const stdout = execSync(`docker compose --file="${composeFile}" ps --format json`, {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    const services: ComposePsService[] = [];
+    for (const line of stdout.split("\n")) {
+      if (line.trim().length === 0) {
+        continue;
+      }
+      const parsed: unknown = JSON.parse(line);
+      if (!isComposePsService(parsed)) {
+        throw new Error(`Unexpected docker compose ps entry shape: ${line}`);
+      }
+      services.push(parsed);
+    }
+    // services without a healthcheck report Health as "" — treat those as ready once running
+    const allReady = services.every((s) => s.State === "running" && (s.Health === "healthy" || s.Health === ""));
+    if (services.length > 0 && allReady) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+  }
+  throw new Error(`docker-compose containers failed to become healthy after ${maxAttempts} attempts`);
+}

--- a/template/frontend/tests/e2e/fixtures.ts
+++ b/template/frontend/tests/e2e/fixtures.ts
@@ -35,6 +35,7 @@ async function retryingFetch(request: string, init: RequestInit): Promise<Respon
   }
   throw lastError;
 }
+
 // Mirrors tests/setup/faker.ts (used by the vitest unit/compiled projects). Seed once per worker so a
 // failing run can be reproduced with TEST_FAKER_SEED=<logged value>. Playwright runs files in a stable
 // order (no vitest-style shuffle), so seed + order reproduce the sequence.

--- a/template/frontend/tests/e2e/fixtures.ts
+++ b/template/frontend/tests/e2e/fixtures.ts
@@ -1,11 +1,40 @@
 import { faker } from "@faker-js/faker";
 import { AnonymousAuthenticationProvider } from "@microsoft/kiota-abstractions";
-import { FetchRequestAdapter } from "@microsoft/kiota-http-fetchlibrary";
+import { FetchRequestAdapter, HttpClient } from "@microsoft/kiota-http-fetchlibrary";
 import { test as base } from "@playwright/test";
 
 import { type BackendClient, createBackendClient } from "~/generated/open-api/backend/backendClient";
 import { backendBaseUrl } from "./ports";
 
+function hasErrorCode(cause: unknown): cause is { code: string } {
+  return typeof cause === "object" && cause !== null && "code" in cause && typeof cause.code === "string";
+}
+
+// Windows CI resets idle keep-alive sockets the backend has already closed; undici surfaces this as a
+// `fetch failed` / ECONNRESET and does NOT auto-retry non-idempotent requests (e.g. POST /api/git/clone).
+// A long gap with no backend traffic (the git work in createGenericRepo) makes the reset likely, so retry
+// the transport here. The reset happens before the request reaches the server, so re-sending is safe.
+async function retryingFetch(request: string, init: RequestInit): Promise<Response> {
+  const maxAttempts = 4;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fetch(request, init);
+    } catch (error) {
+      const isConnectionReset =
+        error instanceof TypeError &&
+        "cause" in error &&
+        hasErrorCode(error.cause) &&
+        error.cause.code === "ECONNRESET";
+      if (!isConnectionReset) {
+        throw error;
+      }
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+    }
+  }
+  throw lastError;
+}
 // Mirrors tests/setup/faker.ts (used by the vitest unit/compiled projects). Seed once per worker so a
 // failing run can be reproduced with TEST_FAKER_SEED=<logged value>. Playwright runs files in a stable
 // order (no vitest-style shuffle), so seed + order reproduce the sequence.
@@ -16,7 +45,12 @@ const fakerSeed = Number.isNaN(parsedSeed) ? Math.floor(Math.random() * 1e9) : p
 // baseUrl — keeps this test harness free of a nuxt-common dependency. This is the same adapter
 // useKiotaClient constructs internally.
 function buildBackendClient(): BackendClient {
-  const adapter = new FetchRequestAdapter(new AnonymousAuthenticationProvider());
+  const adapter = new FetchRequestAdapter(
+    new AnonymousAuthenticationProvider(),
+    undefined,
+    undefined,
+    new HttpClient(retryingFetch),
+  );
   adapter.baseUrl = backendBaseUrl();
   return createBackendClient(adapter);
 }

--- a/template/frontend/tests/e2e/fixtures.ts
+++ b/template/frontend/tests/e2e/fixtures.ts
@@ -30,7 +30,9 @@ async function retryingFetch(request: string, init: RequestInit): Promise<Respon
         throw error;
       }
       lastError = error;
-      await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+      if (attempt < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+      }
     }
   }
   throw lastError;

--- a/template/frontend/tests/e2e/fixtures.ts
+++ b/template/frontend/tests/e2e/fixtures.ts
@@ -50,8 +50,8 @@ const fakerSeed = Number.isNaN(parsedSeed) ? Math.floor(Math.random() * 1e9) : p
 function buildBackendClient(): BackendClient {
   const adapter = new FetchRequestAdapter(
     new AnonymousAuthenticationProvider(),
-    undefined,
-    undefined,
+    undefined, // parseNodeFactory — use default
+    undefined, // serializationWriterFactory — use default
     new HttpClient(retryingFetch),
   );
   adapter.baseUrl = backendBaseUrl();

--- a/template/frontend/tests/e2e/global-setup.ts
+++ b/template/frontend/tests/e2e/global-setup.ts
@@ -1,9 +1,10 @@
-import { execSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { APP_NAME, DEPLOYED_BACKEND_PORT_NUMBER } from "../setup/constants";
+import { composeUp, waitForComposeHealthy } from "./compose";
 import { backendBaseUrl, isBuiltBackendE2E, isDockerComposeE2E } from "./ports";
 
 // Brings up the app the E2E suite runs against, then waits until it is healthy. Runs once before
@@ -39,58 +40,6 @@ async function waitForHttpHealthcheck({
   throw new Error(`Timeout waiting for ${url}`);
 }
 
-interface ComposePsService {
-  Service: string;
-  Health: string;
-  State: string;
-}
-
-function isComposePsService(value: unknown): value is ComposePsService {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  if (!("Service" in value) || typeof value.Service !== "string") {
-    return false;
-  }
-  if (!("Health" in value) || typeof value.Health !== "string") {
-    return false;
-  }
-  if (!("State" in value) || typeof value.State !== "string") {
-    return false;
-  }
-  return true;
-}
-
-async function waitForComposeHealthy({
-  maxAttempts = 30,
-  retryDelayMs = 2000,
-}: { maxAttempts?: number; retryDelayMs?: number } = {}): Promise<void> {
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    const stdout = execSync(`docker compose --file="${dockerComposeFile}" ps --format json`, {
-      encoding: "utf-8",
-      timeout: 10000,
-    });
-    const services: ComposePsService[] = [];
-    for (const line of stdout.split("\n")) {
-      if (line.trim().length === 0) {
-        continue;
-      }
-      const parsed: unknown = JSON.parse(line);
-      if (!isComposePsService(parsed)) {
-        throw new Error(`Unexpected docker compose ps entry shape: ${line}`);
-      }
-      services.push(parsed);
-    }
-    // services without a healthcheck report Health as "" — treat those as ready once running
-    const allReady = services.every((s) => s.State === "running" && (s.Health === "healthy" || s.Health === ""));
-    if (services.length > 0 && allReady) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
-  }
-  throw new Error(`docker-compose containers failed to become healthy after ${maxAttempts} attempts`);
-}
-
 function startBuiltBackend(): void {
   if (!fs.existsSync(executablePath) || !fs.statSync(executablePath).isFile()) {
     throw new Error(`File not found: ${executablePath}`);
@@ -124,12 +73,7 @@ export default async function globalSetup(): Promise<void> {
   if (isDockerComposeE2E) {
     console.log("Starting docker-compose...");
     process.env.DEPLOYED_BACKEND_PORT_NUMBER = DEPLOYED_BACKEND_PORT_NUMBER.toString();
-    execSync(
-      `docker compose --file="${dockerComposeFile}" up --detach --force-recreate --renew-anon-volumes --remove-orphans`,
-      {
-        stdio: "inherit",
-      },
-    );
-    await waitForComposeHealthy();
+    composeUp({ composeFile: dockerComposeFile });
+    await waitForComposeHealthy({ composeFile: dockerComposeFile });
   }
 }

--- a/template/frontend/tests/e2e/global-teardown.ts
+++ b/template/frontend/tests/e2e/global-teardown.ts
@@ -1,9 +1,9 @@
-import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { APP_NAME } from "../setup/constants";
+import { composeDown } from "./compose";
 import { backendBaseUrl, isBuiltBackendE2E, isDockerComposeE2E } from "./ports";
 
 const repoRoot = path.resolve(fileURLToPath(new URL("../../../", import.meta.url)));
@@ -55,6 +55,6 @@ export default async function globalTeardown(): Promise<void> {
   }
   if (isDockerComposeE2E) {
     console.log("Stopping docker-compose...");
-    execSync(`docker compose --file="${dockerComposeFile}" down --volumes`, { stdio: "inherit" });
+    composeDown({ composeFile: dockerComposeFile });
   }
 }


### PR DESCRIPTION
## Why is this change necessary?
Some apps are executables, but have services that need docker compose for full E2E testing


## How does this change address the issue?
Breaks out the docker compose helpers so that other things besides "global setup" can use them


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repo using executable, and a standard one just with docker containers


## Other
Also found some flakiness on Windows CI in E2E, so added some retries to the Kiota adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automatic retrying for HTTP requests in end-to-end tests and switched the backend test client to use it, improving resilience to transient network errors.
  * E2E startup now waits for services to report ready/healthy before running tests.

* **Chores**
  * Moved Docker Compose lifecycle and health-check logic into shared helpers and updated global test setup/teardown to use them for clearer, modular test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->