### PR TITLE
Fix mutmut regex

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
@@ -92,7 +92,7 @@ do_not_mutate_patterns = [
     'logger\.\w+',
     # disable mutations of assert statements (for type narrowing...it often messes with the messages)
     'assert .+',
-    'f"Expected .+, got.+\{\(type\(.+\}.+\{.+',
+    'f"Expected .+, got.+\{type\(.+\}.+\{.+',
     # disable mutating untested exceptions
     'raise NotImplementedError.+',
     'raise AssertionError.+',


### PR DESCRIPTION
Accidentally had an extra parentheses

Removes it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined testing configuration to improve error message pattern matching accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->