### PR TITLE
Disable rich rendering in structlog

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133-3-gc72d742
+_commit: v0.0.133-4-g8218153
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133-6-geff4282
+_commit: v0.0.133-8-g095c446
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133-5-gecf3600
+_commit: v0.0.133-6-geff4282
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133-8-g095c446
+_commit: v0.0.134
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133
+_commit: v0.0.133-3-gc72d742
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.133-4-g8218153
+_commit: v0.0.133-5-gecf3600
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,12 +7,6 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "features": {
-    "ghcr.io/devcontainers/features/python:1.8.0": {
-      // https://github.com/devcontainers/features/blob/main/src/python/devcontainer-feature.json
-      "version": "3.12.7",
-      "installTools": false,
-      "optimize": true
-    },
     // https://github.com/anthropics/devcontainer-features/blob/main/src/claude-code/devcontainer-feature.json
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0.5": {},
   },
@@ -22,16 +16,14 @@
       "extensions": [
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.19.2",
+        "coderabbit.coderabbit-vscode@0.20.0",
         "ms-vscode.live-server@0.5.2025051301",
         "MS-vsliveshare.vsliveshare@1.0.5905",
-        "github.copilot@1.388.0",
-        "github.copilot-chat@0.44.2",
-        "anthropic.claude-code@2.1.145",
+        "anthropic.claude-code@2.1.169",
 
         // Python
-        "ms-python.python@2026.5.2026032701",
-        "ms-python.vscode-pylance@2026.2.100",
+        "ms-python.python@2026.5.2026052901",
+        "ms-python.vscode-pylance@2026.2.104",
         "ms-vscode-remote.remote-containers@0.414.0",
         "charliermarsh.ruff@2026.44.0",
 
@@ -65,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4e1bfbbd # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): bdc60680 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): bdc60680 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 0f6ad136 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d0d8d13a # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 497c90af # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,5 +57,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 0f6ad136 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): d0d8d13a # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -7,8 +7,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-UV_VERSION = "0.11.17"
-PNPM_VERSION = "11.5.0"
+UV_VERSION = "0.11.19"
+PNPM_VERSION = "11.5.2"
 COPIER_VERSION = "==9.15.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "==0.3.3"
 PRE_COMMIT_VERSION = "4.5.1"

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -19,4 +19,4 @@ npm install -g @beads/bd@0.57.0 # no specific reason for this version, just pinn
 
 pre-commit install --install-hooks
 
-python .devcontainer/manual-setup-deps.py --optionally-check-lock
+python .devcontainer/manual-setup-deps.py --optionally-check-lock --allow-uv-to-install-python

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -12,8 +12,8 @@ class ContextUpdater(ContextHook):
     def hook(  # noqa: PLR0915 # yes, this is a lot of statements, but it's all just creating the dict
         self, context: dict[Any, Any]
     ) -> dict[Any, Any]:
-        context["uv_version"] = "0.11.17"
-        context["pnpm_version"] = "11.5.0"
+        context["uv_version"] = "0.11.19"
+        context["pnpm_version"] = "11.5.2"
         context["npm_version"] = "11.13.0"
         context["nvm_version"] = "0.40.4"
         context["pre_commit_version"] = "4.5.1"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -89,7 +89,7 @@ class ContextUpdater(ContextHook):
         context["vue_eslint_parser_version"] = "^10.4.0"
         context["happy_dom_version"] = "^20.10.1"
         context["node_kiota_bundle_version"] = "1.0.0-preview.102"
-        context["labsync_nuxt_common_version"] = "^0.1.1"
+        context["labsync_nuxt_common_version"] = "^0.1.4"
         context["tanstack_vue_table_version"] = "^8.21.3"
         context["unplugin_auto_import_version"] = "^21.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
     "pyright[nodejs]>=1.1.410",
+    "pyrefly>=1.0.0",
     "ty>=0.0.40",
     "copier==9.15.1",
     "copier-template-extensions==0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",
     "pytest-randomly>=4.1.0",
+    "faker>=40.21.0",
     "pyright[nodejs]>=1.1.410",
     "pyrefly>=1.0.0",
     "ty>=0.0.40",

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -1,0 +1,36 @@
+project-excludes = [
+    # excludes managed by this repository
+    "**/template",
+
+    # excludes managed by template
+    "**/vendor_files",
+    "**/generated/graphql",
+    "**/generated/open_api",
+    "**/copier_template_resources",
+    "**/.claude/plugins", # similar to vendor_files, but these are gitignored and can contain arbitrary code, so exclude from type checking but not mutation testing
+]
+# without this explicit "project-includes" and "search-path", pyrefly struggles to understand the tests folder
+project-includes = [    "src",
+                        "tests"
+                ]
+search-path = ["."]
+disable-project-excludes-heuristics = true # with this being enabled by default, pyrefly things the src is excluded because it's an editable local install
+python-platform = "linux"
+infer-with-first-use = false # more similar to pyright. must define the empty list type when instantiated
+# "strict" enables the maximalist error set plus strict-callable-subtyping and
+# unused-ignore. "preset = all" (every error kind) will be available in v1.1.
+preset = "strict"
+spec-compliant-overloads = true # not sure exactly what this does, but seems like a good idea to be more spec compliant
+ignore-errors-in-generated-code = true # not sure yet how effective this is
+
+[errors]
+# reportPrivateUsage=false in pyright (already covered by ruff SLF001)
+no-access = "ignore"
+# reportMissingTypeStubs=false in pyright
+untyped-import = "ignore"
+
+[[sub-config]]
+matches = "**/tests/**"
+
+[sub-config.errors]
+implicitly-defined-attribute = "ignore"

--- a/template/.devcontainer/devcontainer.json.jinja
+++ b/template/.devcontainer/devcontainer.json.jinja
@@ -18,13 +18,6 @@
       // https://github.com/devcontainers/features/blob/main/src/aws-cli/devcontainer-feature.json
       // view latest version https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
       "version": "2.34.34"
-    },{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
-    "ghcr.io/devcontainers/features/python:1.8.0": {
-      // https://github.com/devcontainers/features/blob/main/src/python/devcontainer-feature.json
-      "version": "{% endraw %}{{ python_version }}{% raw %}",
-      "installTools": false,
-      "optimize": true{% endraw %}{% if deploy_as_executable is defined and deploy_as_executable is sameas(true) %}{% raw %},
-      "enableShared": true{% endraw %}{% endif %}{% raw %}
     },{% endraw %}{% endif %}{% raw %}{% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_typescript is defined and template_uses_typescript is sameas(true) %}{% raw %}
     "ghcr.io/devcontainers/features/node:2.0.0": {
       // https://github.com/devcontainers/features/blob/main/src/node/devcontainer-feature.json
@@ -42,16 +35,14 @@
         "-AmazonWebServices.aws-toolkit-vscode", // the AWS CLI feature installs this automatically, but it's causing problems in VS Code{% endraw %}{% endif %}{% raw %}
         // basic tooling
         // "eamodio.gitlens@15.5.1",
-        "coderabbit.coderabbit-vscode@0.19.2",
+        "coderabbit.coderabbit-vscode@0.20.0",
         "ms-vscode.live-server@0.5.2025051301",
-        "MS-vsliveshare.vsliveshare@1.0.5905",
-        "github.copilot@1.388.0",
-        "github.copilot-chat@0.44.2",{% endraw %}{% if install_claude_cli %}{% raw %}
-        "anthropic.claude-code@2.1.145",{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
+        "MS-vsliveshare.vsliveshare@1.0.5905",{% endraw %}{% if install_claude_cli %}{% raw %}
+        "anthropic.claude-code@2.1.169",{% endraw %}{% endif %}{% raw %}{% endraw %}{% if (is_child_of_copier_base_template is defined and is_child_of_copier_base_template is sameas(true)) or (is_child_of_copier_base_template is not defined and template_uses_python is defined and template_uses_python is sameas(true)) %}{% raw %}
 
         // Python
-        "ms-python.python@2026.5.2026032701",
-        "ms-python.vscode-pylance@2026.2.100",
+        "ms-python.python@2026.5.2026052901",
+        "ms-python.vscode-pylance@2026.2.104",
         "ms-vscode-remote.remote-containers@0.414.0",
         "charliermarsh.ruff@2026.44.0",{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if is_child_of_copier_base_template is not defined and template_uses_vuejs is defined and template_uses_vuejs is sameas(true) %}{% raw %}

--- a/template/.devcontainer/on-create-command.sh.jinja
+++ b/template/.devcontainer/on-create-command.sh.jinja
@@ -19,4 +19,4 @@ npm install -g @beads/bd@0.57.0 # no specific reason for this version, just pinn
 
 pre-commit install --install-hooks{% endraw %}{% if python_package_registry is not defined or python_package_registry == "PyPI" %}
 
-{% raw %}python .devcontainer/manual-setup-deps.py --optionally-check-lock{% endraw %}{% endif %}
+{% raw %}python .devcontainer/manual-setup-deps.py --optionally-check-lock --allow-uv-to-install-python{% endraw %}{% endif %}

--- a/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
@@ -15,7 +15,7 @@ dependencies = [
     "uuid-utils{% endraw %}{{ uuid_utils_version }}{% raw %}",{% endraw %}{% if backend_uses_graphql %}{% raw %}
     "strawberry-graphql{% endraw %}{{ strawberry_graphql_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
     "pip-system-certs>=5.3",{% endraw %}{% if install_as_windows_service %}{% raw %}
-    "pywin32>=311; sys_platform == 'win32'",{% endraw %}{% endif %}{% raw %}
+    "pywin32>=312; sys_platform == 'win32'",{% endraw %}{% endif %}{% raw %}
     "pydantic{% endraw %}{{ pydantic_version }}{% raw %}",
     "uvicorn{% endraw %}{{ uvicorn_version }}{% raw %}",
     "structlog{% endraw %}{{ structlog_version }}{% raw %}",{% endraw %}{% if backend_source_uses_kiota %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
+++ b/template/{% if has_backend %}backend{% endif %}/pyproject.toml.jinja
@@ -46,8 +46,8 @@ dev = [
     "pytest{% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov{% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly{% endraw %}{{ pytest_randomly_version }}{% raw %}",
-    "pytest-mock{% endraw %}{{ pytest_mock_version }}{% raw %}",{% endraw %}{% if install_as_windows_service %}{% raw %}
-    "pytest-timeout{% endraw %}{{ pytest_timeout_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
+    "pytest-mock{% endraw %}{{ pytest_mock_version }}{% raw %}",
+    "pytest-timeout{% endraw %}{{ pytest_timeout_version }}{% raw %}",
     "pytest-asyncio{% endraw %}{{ pytest_asyncio_version }}{% raw %}",{% endraw %}{% if backend_makes_api_calls %}{% raw %}
     "pytest-recording{% endraw %}{{ pytest_recording_version }}{% raw %}",
     "mutmut{% endraw %}{{ mutmut_version }}{% raw %}",

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/logger_config.py
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/logger_config.py
@@ -95,8 +95,8 @@ def configure_logging(
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         # Force plain_traceback: when `rich` is importable, ConsoleRenderer defaults to
         # RichTracebackFormatter, which pygments-highlights the entire stack and reprs every
-        # frame's locals on each logged exception. That made error-path tests ~18x slower once
-        # rich was pulled in as a transitive dev dependency. plain_traceback keeps it cheap.
+        # frame's locals on each logged exception. That made error-path tests dramatically slower once
+        # rich was pulled in as a transitive dev dependency (structlog v26). plain_traceback keeps it cheap.
         structlog.dev.ConsoleRenderer(colors=True, exception_formatter=structlog.dev.plain_traceback),
     ]
     handlers = ["file"]

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/logger_config.py
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/logger_config.py
@@ -93,7 +93,11 @@ def configure_logging(
         *shared_processors,
         structlog.processors.EventRenamer(to="message"),
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-        structlog.dev.ConsoleRenderer(colors=True),
+        # Force plain_traceback: when `rich` is importable, ConsoleRenderer defaults to
+        # RichTracebackFormatter, which pygments-highlights the entire stack and reprs every
+        # frame's locals on each logged exception. That made error-path tests ~18x slower once
+        # rich was pulled in as a transitive dev dependency. plain_traceback keeps it cheap.
+        structlog.dev.ConsoleRenderer(colors=True, exception_formatter=structlog.dev.plain_traceback),
     ]
     handlers = ["file"]
     if not suppress_console_logging:  # pragma: no cover # we need to just move this into a library...this repo shouldn't be testing the logging config

--- a/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
+++ b/tests/unit/copier_tasks/test_ensure_pnpm_minimum_release_age_exclude.py
@@ -1,21 +1,13 @@
 import subprocess
-import uuid
 from pathlib import Path
 
 import yaml
+from faker import Faker
 
 from .helpers import run_copier_task
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _SCRIPT_PATH = _PROJECT_ROOT / "src" / "copier_tasks" / "ensure_pnpm_minimum_release_age_exclude.py"
-
-
-def _pkg() -> str:
-    return uuid.uuid4().hex[:8]
-
-
-def _scoped_pkg() -> str:
-    return f"@{uuid.uuid4().hex[:4]}/{uuid.uuid4().hex[:6]}"
 
 
 class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
@@ -28,24 +20,28 @@ class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
     ) -> subprocess.CompletedProcess[str]:
         return run_copier_task(_SCRIPT_PATH, "--patterns", patterns, "--target-dir", str(target_dir), env=env)
 
-    def test_When_pnpm_not_on_path__Then_exits_nonzero_with_error(self, tmp_path: Path) -> None:
+    def test_When_pnpm_not_on_path__Then_exits_nonzero_with_error(self, tmp_path: Path, faker: Faker) -> None:
         _ = (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - frontend\n", encoding="utf-8")
 
-        result = self._run_script(patterns=_pkg(), target_dir=tmp_path, env={"PATH": ""})
+        result = self._run_script(patterns=faker.name(), target_dir=tmp_path, env={"PATH": ""})
 
         assert result.returncode != 0
         assert "pnpm" in result.stdout
 
-    def test_When_target_dir_has_no_workspace_file__Then_exits_0_and_reports_skipping(self, tmp_path: Path) -> None:
-        result = self._run_script(patterns=_pkg(), target_dir=tmp_path)
+    def test_When_target_dir_has_no_workspace_file__Then_exits_0_and_reports_skipping(
+        self, tmp_path: Path, faker: Faker
+    ) -> None:
+        result = self._run_script(patterns=faker.name(), target_dir=tmp_path)
 
         assert result.returncode == 0
         assert "not found" in result.stdout
         assert not (tmp_path / "pnpm-workspace.yaml").exists()
 
-    def test_When_workspace_has_existing_patterns__Then_new_patterns_appended(self, tmp_path: Path) -> None:
-        existing = _pkg()
-        new = _pkg()
+    def test_When_workspace_has_existing_patterns__Then_new_patterns_appended(
+        self, tmp_path: Path, faker: Faker
+    ) -> None:
+        existing = faker.name()
+        new = faker.name()
         workspace = tmp_path / "pnpm-workspace.yaml"
         _ = workspace.write_text(f"minimumReleaseAgeExclude: {existing}\n", encoding="utf-8")
 
@@ -55,9 +51,9 @@ class TestEnsurePnpmMinimumReleaseAgeExcludeViaSubprocess:
         parsed = yaml.safe_load(workspace.read_text(encoding="utf-8"))
         assert parsed["minimumReleaseAgeExclude"] == f"{existing},{new}"
 
-    def test_When_patterns_provided__Then_sets_value_in_workspace(self, tmp_path: Path) -> None:
-        scoped = _scoped_pkg()
-        plain = _pkg()
+    def test_When_patterns_provided__Then_sets_value_in_workspace(self, tmp_path: Path, faker: Faker) -> None:
+        scoped = f"{faker.name()}/{faker.name()}"
+        plain = faker.name()
         workspace = tmp_path / "pnpm-workspace.yaml"
         _ = workspace.write_text("packages:\n  - frontend\n", encoding="utf-8")
 

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "copier" },
     { name = "copier-template-extensions" },
+    { name = "faker" },
     { name = "pyrefly" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
@@ -63,6 +64,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = "==9.15.1" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
+    { name = "faker", specifier = ">=40.21.0" },
     { name = "pyrefly", specifier = ">=1.0.0" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.410" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -157,6 +159,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/4e/a5c8c337a1d9ac0384298ade02d322741fb5998041a5ea74d1cd2a4a1d47/dunamai-1.23.0.tar.gz", hash = "sha256:a163746de7ea5acb6dacdab3a6ad621ebc612ed1e528aaa8beedb8887fccd2c4", size = 44681, upload-time = "2024-11-18T00:00:27.087Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/4c/963169386309fec4f96fd61210ac0a0666887d0fb0a50205395674d20b71/dunamai-1.23.0-py3-none-any.whl", hash = "sha256:a0906d876e92441793c6a423e16a4802752e723e9c9a5aabdc5535df02dbe041", size = 26342, upload-time = "2024-11-18T00:00:25.683Z" },
+]
+
+[[package]]
+name = "faker"
+version = "40.21.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6f/d7b251fb31de7dce0e482680bf7ca876aa0043f475c04aeefa1459ea80d4/faker-40.21.0.tar.gz", hash = "sha256:2fdee1b650a723a54432db9c6dfe17cfa29d1adc8bd60520444a07698524ba4d", size = 1970295, upload-time = "2026-06-02T17:53:46.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/77/6adb5a9dcd028f687f81fc9f789591f9572cb5a46454337122add004e134/faker-40.21.0-py3-none-any.whl", hash = "sha256:cb6601b2ae8e128895dc96814d271eab6b930a2d2d7932c6f9ff26785c24ee18", size = 2008808, upload-time = "2026-06-02T17:53:44.346Z" },
 ]
 
 [[package]]
@@ -547,6 +561,15 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload-time = "2024-06-07T18:52:15.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload-time = "2024-06-07T18:52:13.582Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "copier" },
     { name = "copier-template-extensions" },
+    { name = "pyrefly" },
     { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -62,6 +63,7 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = "==9.15.1" },
     { name = "copier-template-extensions", specifier = "==0.3.3" },
+    { name = "pyrefly", specifier = ">=1.0.0" },
     { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.410" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -383,6 +385,23 @@ source = { registry = "https://pypi.org/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/3a/9045b0097ac58979c7c30a4fa0e673db942d4adbc7b6d439bd54ae58c441/pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455", size = 5677995, upload-time = "2026-05-12T20:12:46.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6", size = 13122950, upload-time = "2026-05-12T20:12:20.711Z" },
+    { url = "https://files.pythonhosted.org/packages/82/91/a3cf2a1e87d336eaa804a1e6fc93266faf6dc2a97eecdbc7eae289628022/pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3", size = 12599494, upload-time = "2026-05-12T20:12:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416", size = 12995507, upload-time = "2026-05-12T20:12:25.951Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ac/2df0899f8464c97e5d995f994c97c5cb5b0f58610432aa90d26d924e1db5/pyrefly-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c74219d8f3e63cdaa5501a0b21d1c9d37011820f9606728d0ed06f09ae86a878", size = 13947693, upload-time = "2026-05-12T20:12:29.188Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3e/b247c24321e36f04b7d51f9ccf3df93e5009e4b29939524b36ec2e17dc2a/pyrefly-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0d05543b1bb6ee6d64149eb5d6b2fb15aa72d3962d6a97abca0afaca8b0c131", size = 13925803, upload-time = "2026-05-12T20:12:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc", size = 13470398, upload-time = "2026-05-12T20:12:35.302Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/6372c7dddb326223e24a46b17efd0d4bd7b4fe22c821e523157577eed2d2/pyrefly-1.0.0-py3-none-win32.whl", hash = "sha256:aa8b5d0e47080e3202a2547b39f7a5a61d2c781c712b3b67884f745ca2c759d2", size = 12222643, upload-time = "2026-05-12T20:12:38.618Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ad/1d23be700b6b2ddaeb362360c7145917a8edbbf7240ae428d40541772fce/pyrefly-1.0.0-py3-none-win_amd64.whl", hash = "sha256:c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5", size = 13146369, upload-time = "2026-05-12T20:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/38/16589134f3012fd097a10dcc85771555f1a5fb76e04b682597180743af30/pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c", size = 12538326, upload-time = "2026-05-12T20:12:43.996Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why is this change necessary?
Structlog v26 brought in `rich` dependency, which made unit test suites run really slow. 


## How does this change address the issue?
Disables the extra rich console rendering


## What side effects does this change have?
N/A


## How is this change tested?
Downstream repos


## Other
pytest-timeout is needed in all versions of the template, not just as a windows service, so fixed the jinja clause in pyproject.toml.jinja

Pulls in some other upstream template changes for using uv to install python