### PR TITLE
Add vscode workspace file

### DIFF
--- a/template/{{ repo_name }}.code-workspace.jinja
+++ b/template/{{ repo_name }}.code-workspace.jinja
@@ -1,14 +1,14 @@
-{
+{% raw %}{
     "folders": [
         {
             "name": "frontend",
             "path": "frontend"
         },
-        {% if has_backend %}{
+        {% endraw %}{% if has_backend %}{
             "name": "backend",
             "path": "backend"
         },
-        {% endif %}{
+        {% endif %}{% raw %}{
             "name": "root",
             "path": "."
         }
@@ -24,7 +24,7 @@
         // Vitest Explorer needs an explicit pointer in a multi-root workspace
         "vitest.rootConfig": "${workspaceFolder:frontend}/vitest.config.ts",
 
-        {% if has_backend %}// Backend (Python / uv)
+        {% endraw %}{% if has_backend %}{% raw %}// Backend (Python / uv)
         // Sets the default interpreter to the virtual environment managed by uv
         "python.defaultInterpreterPath": "${workspaceFolder:backend}/.venv/bin/python",
         // Disables automatic venv activation — uv manages the environment
@@ -33,11 +33,11 @@
         // an absolute /workspaces/ path that breaks outside the container)
         "ruff.configuration": "${workspaceFolder:root}/ruff-non-src.toml",
 
-        {% endif %}"files.exclude": {
+        {% endraw %}{% endif %}{% raw %}"files.exclude": {
             // Excluding service dirs since they are imported as their own workspace folders
-            "frontend": true{% if has_backend %},
-            "backend": true{% endif %}
+            "frontend": true{% endraw %}{% if has_backend %},
+            "backend": true{% endif %}{% raw %}
 
         }
     }
-}
+}{% endraw %}

--- a/template/{{ repo_name }}.code-workspace.jinja
+++ b/template/{{ repo_name }}.code-workspace.jinja
@@ -18,13 +18,9 @@
         "workbench.editor.labelFormat": "medium",
 
         // Frontend (Nuxt / Vue)
-        // Ensures Volar uses the project's TypeScript rather than VS Code's bundled version,
+        // Ensures language server uses the project's TypeScript rather than VS Code's bundled version,
         // which is required for Nuxt's auto-generated .nuxt/tsconfig.json types to resolve
         "typescript.tsdk": "${workspaceFolder:frontend}/node_modules/typescript/lib",
-        // Volar 3.x hybrid mode — dedicated Vue language server alongside the TS server
-        "vue.server.hybridMode": true,
-        // ESLint flat config (eslint.config.mjs)
-        "eslint.useFlatConfig": true,
         // Vitest Explorer needs an explicit pointer in a multi-root workspace
         "vitest.rootConfig": "${workspaceFolder:frontend}/vitest.config.ts",
 

--- a/template/{{ repo_name }}.code-workspace.jinja
+++ b/template/{{ repo_name }}.code-workspace.jinja
@@ -1,0 +1,47 @@
+{
+    "folders": [
+        {
+            "name": "frontend",
+            "path": "frontend"
+        },
+        {% if has_backend %}{
+            "name": "backend",
+            "path": "backend"
+        },
+        {% endif %}{
+            "name": "root",
+            "path": "."
+        }
+    ],
+    "settings": {
+        // Shows the workspace name in the status bar
+        "workbench.editor.labelFormat": "medium",
+
+        // Frontend (Nuxt / Vue)
+        // Ensures Volar uses the project's TypeScript rather than VS Code's bundled version,
+        // which is required for Nuxt's auto-generated .nuxt/tsconfig.json types to resolve
+        "typescript.tsdk": "${workspaceFolder:frontend}/node_modules/typescript/lib",
+        // Volar 3.x hybrid mode — dedicated Vue language server alongside the TS server
+        "vue.server.hybridMode": true,
+        // ESLint flat config (eslint.config.mjs)
+        "eslint.useFlatConfig": true,
+        // Vitest Explorer needs an explicit pointer in a multi-root workspace
+        "vitest.rootConfig": "${workspaceFolder:frontend}/vitest.config.ts",
+
+        {% if has_backend %}// Backend (Python / uv)
+        // Sets the default interpreter to the virtual environment managed by uv
+        "python.defaultInterpreterPath": "${workspaceFolder:backend}/.venv/bin/python",
+        // Disables automatic venv activation — uv manages the environment
+        "python.terminal.activateEnvironment": false,
+        // Works for both devcontainer and non-devcontainer users (devcontainer.json hardcodes
+        // an absolute /workspaces/ path that breaks outside the container)
+        "ruff.configuration": "${workspaceFolder:root}/ruff-non-src.toml",
+
+        {% endif %}"files.exclude": {
+            // Excluding service dirs since they are imported as their own workspace folders
+            "frontend": true{% if has_backend %},
+            "backend": true{% endif %}
+
+        }
+    }
+}


### PR DESCRIPTION
## Link to Issue or Message thread
DM


## Why is this change necessary?
We want VSCode to handle the frontend and backend projects. When they are one big root it can get confused and breaks things like running tests and such. 


## How does this change address the issue?
Adds a workspace file for VSCode and configures it to know where the .venv is and the typescript project. 


## What side effects does this change have?
None - this is 100% opt-in. If you want to use it in VSCode you can and it should make your experience better. 


## How is this change tested?
Downstream




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added VS Code workspace configuration template with multi-root support and pre-configured development environment settings for TypeScript and Python development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->