### PR TITLE
Bump some versions to support new nuxt-common version

### DIFF
--- a/.claude/skills/address-pr-comments/fetch-pr-comments.py
+++ b/.claude/skills/address-pr-comments/fetch-pr-comments.py
@@ -70,6 +70,7 @@ def gh_rest(*args: str) -> Any:  # noqa: ANN401 — return type is genuinely unk
         ["gh", *call_args],  # noqa: S607 — gh is expected on PATH
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )
@@ -91,6 +92,7 @@ def gh_graphql(query: str, variables: dict[str, str | int]) -> Any:  # noqa: ANN
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )
@@ -105,6 +107,7 @@ def fetch_current_user_login() -> str:
         ["gh", "api", "user", "--jq", ".login"],  # noqa: S607 — gh is expected on PATH
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.144-3-ga3ab3bf3
+_commit: v0.0.144-4-g87e1d30b
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.144
+_commit: v0.0.144-2-gf4568b34
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.144-5-g05ff7d7a
+_commit: v0.0.145
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.144-4-g87e1d30b
+_commit: v0.0.144-5-g05ff7d7a
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.144-2-gf4568b34
+_commit: v0.0.144-3-ga3ab3bf3
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -66,7 +66,7 @@ class ContextUpdater(ContextHook):
         context["pyrefly_version"] = ">=1.1.1"
 
         context["default_node_version"] = "24.11.1"
-        context["nuxt_ui_version"] = "^4.8.1"
+        context["nuxt_ui_version"] = "^4.10.0"
         context["nuxt_version"] = "^4.4.6"
         context["nuxt_icon_version"] = "^2.2.1"
         context["typescript_version"] = "^6.0.2"
@@ -96,9 +96,10 @@ class ContextUpdater(ContextHook):
         context["vue_eslint_parser_version"] = "^10.4.0"
         context["happy_dom_version"] = "^20.10.1"
         context["node_kiota_bundle_version"] = "1.0.0-preview.103"
-        context["labsync_nuxt_common_version"] = "^0.1.4"
+        context["labsync_nuxt_common_version"] = "^0.2.3"
         context["tanstack_vue_table_version"] = "^8.21.3"
         context["unplugin_auto_import_version"] = "^21.0.0"
+        context["openapi_types_version"] = "^12.1.3"
 
         context["gha_checkout"] = "v6.0.2"
         context["gha_setup_python"] = "v6.2.0"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -64,6 +64,7 @@ class ContextUpdater(ContextHook):
         context["python_faker_version"] = ">=40.35.0"
         context["mutmut_version"] = ">=3.6.0"
         context["pyrefly_version"] = ">=1.1.1"
+        context["vacuum_openapi_version"] = "0.30.0"
 
         context["default_node_version"] = "24.11.1"
         context["nuxt_ui_version"] = "^4.10.0"

--- a/template/.claude/skills/address-pr-comments/fetch-pr-comments.py
+++ b/template/.claude/skills/address-pr-comments/fetch-pr-comments.py
@@ -70,6 +70,7 @@ def gh_rest(*args: str) -> Any:  # noqa: ANN401 — return type is genuinely unk
         ["gh", *call_args],  # noqa: S607 — gh is expected on PATH
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )
@@ -91,6 +92,7 @@ def gh_graphql(query: str, variables: dict[str, str | int]) -> Any:  # noqa: ANN
         args,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )
@@ -105,6 +107,7 @@ def fetch_current_user_login() -> str:
         ["gh", "api", "user", "--jq", ".login"],  # noqa: S607 — gh is expected on PATH
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=True,
         timeout=GH_TIMEOUT_SECONDS,
     )

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -71,7 +71,8 @@
     "graphql": "^16.14.0",
     "graphql-tag": "^2.12.6",{% endraw %}{% endif %}{% raw %}
     "happy-dom": "{% endraw %}{{ happy_dom_version }}{% raw %}",{% endraw %}{% if frontend_uses_graphql %}{% raw %}
-    "mock-apollo-client": "^1.4.0",{% endraw %}{% endif %}{% raw %}
+    "mock-apollo-client": "^1.4.0",{% endraw %}{% endif %}{% if is_circuit_python_driver %}{% raw %}
+    "openapi-types": "{% endraw %}{{ openapi_types_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
     "playwright": "{% endraw %}{{ playwright_version }}{% raw %}",
     "playwright-core": "{% endraw %}{{ playwright_version }}{% raw %}",
     "postcss": "^8.5.14",


### PR DESCRIPTION
## Why is this change necessary?
Keep things up to date 


## How does this change address the issue?
0.2.3 declares `@nuxt/ui >=4.10.0` and a non-optional `openapi-types >=12.1` peer dependency, so bump @nuxt/ui and add openapi-types as a dev dependency for driver projects.


## What side effects does this change have?
N/A


## How is this change tested?
CI and downstream


<!--
============== WARNING ==============================================================================
File is managed by copier template: gh:LabAutomationAndScreening/copier-base-template.git
See .config/.copier-managed-files.json for details.

You are welcome to make changes to this file in your repo if they are custom to your project,
but if the change should be shared with other projects, please backport it to the template repo.
=====================================================================================================
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAPI type support for projects using the Python driver template.
  * Updated frontend tooling and shared component versions for improved compatibility.

* **Bug Fixes**
  * Improved consistency when processing command-line output across different environments by enforcing UTF-8 text handling.

* **Chores**
  * Updated project template metadata to the latest revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->