### PR TITLE
Copier update: hadolint hook

### DIFF
--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.145
+_commit: v0.0.146
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,5 +60,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): ac4f3818 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 1d25b71a # spellchecker:disable-line
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -235,6 +235,9 @@ repos:
     hooks:
       - id: hadolint-docker
         name: Lint Dockerfiles
+        # The hadolint pre-commit has a problem where it just always pulls the `latest` image at runtime.
+        # Explicitly pinning the image here to the same rev as the hook to patch it until https://github.com/hadolint/hadolint/pull/1177 gets resolved.
+        entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
         exclude: .*\.jinja$
         description: Runs hadolint to lint Dockerfiles
 

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -276,6 +276,9 @@ repos:
     hooks:
       - id: hadolint-docker
         name: Lint Dockerfiles
+        # The hadolint pre-commit has a problem where it just always pulls the `latest` image at runtime.
+        # Explicitly pinning the image here to the same rev as the hook to patch it until https://github.com/hadolint/hadolint/pull/1177 gets resolved.
+        entry: ghcr.io/hadolint/hadolint:v2.14.0@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e hadolint
         exclude: .*\.jinja$
         description: Runs hadolint to lint Dockerfiles
 


### PR DESCRIPTION
Pull in upstream changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project tooling templates to the latest maintenance version.
  * Improved development environment consistency through refreshed configuration metadata.
  * Pinned Dockerfile linting to a verified tool version for more reproducible checks.
  * Applied the same linting reliability improvements to generated project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->