### PR TITLE
Fix flaky windows service smoke tests in CI

### DIFF
--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}crash_dump.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}crash_dump.py{% endif %}
@@ -1,0 +1,35 @@
+import argparse
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+
+from ..jinja_constants import APP_NAME
+from .parser import parser
+
+CRASH_DUMP_FILENAME = "service-crash.log"
+
+
+def resolve_crash_dump_path(service_argv: Sequence[str]) -> Path:
+    """Pick a writable dir for the crash dump.
+
+    Preference order: --log-folder from service_argv (already writable, captured by CI artifact),
+    then the system temp dir (LocalSystem-writable fallback for production installs in
+    Program Files where the exe dir is read-only).
+    """
+    try:
+        args, _ = parser.parse_known_args(service_argv)
+        log_folder = args.log_folder
+        assert log_folder is None or isinstance(log_folder, str)
+    except (argparse.ArgumentError, SystemExit):
+        log_folder = None
+    if log_folder is not None:
+        return Path(log_folder) / CRASH_DUMP_FILENAME
+    return Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
+
+
+def write_crash_dump(*, crash_dump_path: Path, traceback_text: str) -> bool:
+    try:
+        _ = crash_dump_path.write_text(traceback_text, encoding="utf-8")
+    except OSError:
+        return False
+    return True

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}win_service.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}win_service.py{% endif %}
@@ -1,8 +1,6 @@
-import argparse
 import os
 import subprocess
 import sys
-import tempfile
 import threading
 import traceback
 from collections.abc import Sequence
@@ -17,28 +15,11 @@ import winerror  # pyrefly: ignore[missing-import,unused-ignore] # pywin32 has n
 from .. import app_runner
 from ..jinja_constants import APP_NAME
 from ..jinja_constants import HUMAN_FRIENDLY_APP_NAME
+from .crash_dump import resolve_crash_dump_path
+from .crash_dump import write_crash_dump
 from .parser import parser
 
-CRASH_DUMP_FILENAME = "service-crash.log"
 _SERVICE_MANAGEMENT_COMMANDS = frozenset({"install", "start", "stop", "remove", "debug"})
-
-
-def _resolve_crash_dump_path(service_argv: Sequence[str]) -> Path:
-    """Pick a writable dir for the crash dump.
-
-    Preference order: --log-folder from service_argv (already writable, captured by CI artifact),
-    then the system temp dir (LocalSystem-writable fallback for production installs in
-    Program Files where the exe dir is read-only).
-    """
-    try:
-        args, _ = parser.parse_known_args(service_argv)
-        log_folder = args.log_folder
-        assert log_folder is None or isinstance(log_folder, str)
-    except (argparse.ArgumentError, SystemExit):
-        log_folder = None
-    if log_folder is not None:
-        return Path(log_folder) / CRASH_DUMP_FILENAME
-    return Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
 
 
 class AppService(win32serviceutil.ServiceFramework):
@@ -59,6 +40,22 @@ class AppService(win32serviceutil.ServiceFramework):
             if self._worker.is_alive():
                 servicemanager.LogErrorMsg(f"{APP_NAME}: worker did not stop within 30s; SCM will force-terminate")
 
+    def SvcRun(self) -> None:  # noqa: N802 # pywin32 mandates this exact method name
+        # Outermost guard pywin32 hands control to. On a slow SCM startup the status handle can already
+        # be invalid by the time ReportServiceStatus runs, so a crash anywhere — startup, status
+        # reporting, or SvcDoRun itself — could escape before any dump was written. Write the dump as a
+        # fallback on ANY unhandled exception, then re-raise so pywin32 still surfaces the failure to SCM
+        # as ERROR_SERVICE_SPECIFIC_ERROR (1066). Skip the write when SvcDoRun already captured the real
+        # crash: the escaping exception is then the invalid-handle ReportServiceStatus race, whose
+        # traceback would otherwise clobber the genuine worker traceback already on disk.
+        crash_dump_path = resolve_crash_dump_path(sys.argv[2:])
+        try:
+            super().SvcRun()
+        except BaseException:
+            if not crash_dump_path.exists():
+                _ = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback.format_exc())
+            raise
+
     def SvcDoRun(self) -> None:  # noqa: N802 # pywin32 mandates this exact method name
         # TODO: stop reading sys.argv here — couples runtime to global argv layout and the magic [2:] offset.
         # pywin32 passes the command-line args to __init__ via the `args` tuple (args[0] = service name,
@@ -66,13 +63,11 @@ class AppService(win32serviceutil.ServiceFramework):
         # Non-breaking refactor: ImagePath format and installed services unaffected. Also fixes the
         # `service debug` foreground path, which currently feeds "debug" into argparse and crashes.
         service_argv = sys.argv[2:]  # sys.argv[0] = exe path, sys.argv[1] = 'service', sys.argv[2:] = runtime args
-        # SCM runs the service from C:\Windows\System32; daemon-thread exceptions die silently,
-        # so capture any worker crash to a writable file and to the Windows Event Log.
-        crash_dump_path = _resolve_crash_dump_path(service_argv)
-        crashed = False
+        crash_dump_path = resolve_crash_dump_path(service_argv)
+        crash_traceback: str | None = None
 
         def _run() -> None:
-            nonlocal crashed
+            nonlocal crash_traceback
             try:
                 # SCM detaches stdio: sys.stdout/sys.stderr are None. uvicorn's DefaultFormatter
                 # calls sys.stdout.isatty() during __init__ and crashes. Redirect to devnull;
@@ -82,24 +77,21 @@ class AppService(win32serviceutil.ServiceFramework):
                 cli_args = parser.parse_args(service_argv)
                 _ = app_runner.start_app(cli_args, stop_event=self._stop_event)
             except BaseException:  # noqa: BLE001 # service-of-last-resort: must also catch SystemExit from argparse (--version/--help/parse errors) so the failure surfaces to SCM + crash dump instead of silently exiting
-                crashed = True
-                tb = traceback.format_exc()
-                servicemanager.LogErrorMsg(f"{APP_NAME}: worker crashed\n{tb}")
-                try:
-                    _ = crash_dump_path.write_text(tb, encoding="utf-8")
-                except OSError as write_err:
-                    servicemanager.LogErrorMsg(
-                        f"{APP_NAME}: failed to write crash dump to {crash_dump_path}: {write_err}"
-                    )
+                crash_traceback = traceback.format_exc()
                 self._stop_event.set()
-                # don't re-raise: daemon-thread exceptions die silently anyway, and SvcDoRun
-                # reports the non-zero status to SCM below after the worker exits.
+                # don't re-raise: daemon-thread exceptions die silently anyway, so the crash is
+                # captured here and handled on the main service thread below after the worker exits.
 
         self._worker = threading.Thread(target=_run, daemon=True)
         self._worker.start()
         self._worker.join()
 
-        if crashed:
+        if crash_traceback is not None:
+            # Write the dump FIRST and unconditionally — before any event-log or status-reporting call —
+            # so a failing ReportServiceStatus (invalid SCM handle) can never prevent the dump file.
+            if not write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=crash_traceback):
+                servicemanager.LogErrorMsg(f"{APP_NAME}: failed to write crash dump to {crash_dump_path}")
+            servicemanager.LogErrorMsg(f"{APP_NAME}: worker crashed\n{crash_traceback}")
             # ERROR_SERVICE_SPECIFIC_ERROR (1066) signals to SCM that the service stopped due to an
             # app-defined failure; SCM then exposes svcExitCode for the specific failure code. Non-zero
             # exit lets `sc failure` recovery actions fire and lets monitoring distinguish a worker

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}win_service.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/entrypoint/{% if install_as_windows_service %}win_service.py{% endif %}
@@ -31,6 +31,7 @@ class AppService(win32serviceutil.ServiceFramework):
         super().__init__(args)
         self._stop_event = threading.Event()
         self._worker: threading.Thread | None = None
+        self._worker_crash_dump_written = False
 
     def SvcStop(self) -> None:  # noqa: N802 # pywin32 mandates this exact method name
         self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
@@ -47,12 +48,14 @@ class AppService(win32serviceutil.ServiceFramework):
         # fallback on ANY unhandled exception, then re-raise so pywin32 still surfaces the failure to SCM
         # as ERROR_SERVICE_SPECIFIC_ERROR (1066). Skip the write when SvcDoRun already captured the real
         # crash: the escaping exception is then the invalid-handle ReportServiceStatus race, whose
-        # traceback would otherwise clobber the genuine worker traceback already on disk.
+        # traceback would otherwise clobber the genuine worker traceback already on disk. The flag tracks
+        # what THIS invocation wrote — the dump filename is fixed, so a file left by an earlier crashed
+        # run must not suppress capturing the current one.
         crash_dump_path = resolve_crash_dump_path(sys.argv[2:])
         try:
             super().SvcRun()
         except BaseException:
-            if not crash_dump_path.exists():
+            if not self._worker_crash_dump_written:
                 _ = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback.format_exc())
             raise
 
@@ -89,7 +92,10 @@ class AppService(win32serviceutil.ServiceFramework):
         if crash_traceback is not None:
             # Write the dump FIRST and unconditionally — before any event-log or status-reporting call —
             # so a failing ReportServiceStatus (invalid SCM handle) can never prevent the dump file.
-            if not write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=crash_traceback):
+            self._worker_crash_dump_written = write_crash_dump(
+                crash_dump_path=crash_dump_path, traceback_text=crash_traceback
+            )
+            if not self._worker_crash_dump_written:
                 servicemanager.LogErrorMsg(f"{APP_NAME}: failed to write crash dump to {crash_dump_path}")
             servicemanager.LogErrorMsg(f"{APP_NAME}: worker crashed\n{crash_traceback}")
             # ERROR_SERVICE_SPECIFIC_ERROR (1066) signals to SCM that the service stopped due to an

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/entrypoint/{% if install_as_windows_service %}test_crash_dump.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/entrypoint/{% if install_as_windows_service %}test_crash_dump.py{% endif %}
@@ -1,0 +1,51 @@
+import tempfile
+from pathlib import Path
+
+from backend_api.entrypoint.crash_dump import CRASH_DUMP_FILENAME
+from backend_api.entrypoint.crash_dump import resolve_crash_dump_path
+from backend_api.entrypoint.crash_dump import write_crash_dump
+from backend_api.jinja_constants import APP_NAME
+from faker import Faker
+
+
+def test_Given_log_folder_in_service_argv__When_resolved__Then_path_is_log_folder_joined_with_filename(faker: Faker):
+    log_folder = faker.file_path(depth=3, extension="")
+
+    resolved = resolve_crash_dump_path(["--log-folder", log_folder])
+
+    assert resolved == Path(log_folder) / CRASH_DUMP_FILENAME
+
+
+def test_Given_no_log_folder_in_service_argv__When_resolved__Then_path_falls_back_to_tempdir(faker: Faker):
+    resolved = resolve_crash_dump_path(["--port", str(faker.port_number())])
+
+    assert resolved == Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
+
+
+def test_Given_unparsable_service_argv__When_resolved__Then_path_falls_back_to_tempdir_without_raising(faker: Faker):
+    resolved = resolve_crash_dump_path(["--port", faker.word()])
+
+    assert resolved == Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
+
+
+def test_Given_traceback_text__When_crash_dump_written__Then_file_contains_traceback(tmp_path: Path, faker: Faker):
+    crash_dump_path = tmp_path / CRASH_DUMP_FILENAME
+    traceback_text = faker.text()
+
+    wrote = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback_text)
+
+    assert wrote is True
+    assert crash_dump_path.exists()
+    assert crash_dump_path.read_text(encoding="utf-8") == traceback_text
+
+
+def test_Given_unwritable_path__When_crash_dump_written__Then_returns_false_without_raising(
+    tmp_path: Path, faker: Faker
+):
+    crash_dump_path = tmp_path / faker.word() / CRASH_DUMP_FILENAME
+    traceback_text = faker.text()
+
+    wrote = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback_text)
+
+    assert wrote is False
+    assert not crash_dump_path.exists()

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/entrypoint/{% if install_as_windows_service %}test_crash_dump.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/entrypoint/{% if install_as_windows_service %}test_crash_dump.py{% endif %}
@@ -1,36 +1,37 @@
+import random
 import tempfile
 from pathlib import Path
+from uuid import uuid4
 
 from backend_api.entrypoint.crash_dump import CRASH_DUMP_FILENAME
 from backend_api.entrypoint.crash_dump import resolve_crash_dump_path
 from backend_api.entrypoint.crash_dump import write_crash_dump
 from backend_api.jinja_constants import APP_NAME
-from faker import Faker
 
 
-def test_Given_log_folder_in_service_argv__When_resolved__Then_path_is_log_folder_joined_with_filename(faker: Faker):
-    log_folder = faker.file_path(depth=3, extension="")
+def test_Given_log_folder_in_service_argv__When_resolved__Then_path_is_log_folder_joined_with_filename():
+    log_folder = str(Path(tempfile.gettempdir()) / str(uuid4()))
 
     resolved = resolve_crash_dump_path(["--log-folder", log_folder])
 
     assert resolved == Path(log_folder) / CRASH_DUMP_FILENAME
 
 
-def test_Given_no_log_folder_in_service_argv__When_resolved__Then_path_falls_back_to_tempdir(faker: Faker):
-    resolved = resolve_crash_dump_path(["--port", str(faker.port_number())])
+def test_Given_no_log_folder_in_service_argv__When_resolved__Then_path_falls_back_to_tempdir():
+    resolved = resolve_crash_dump_path(["--port", str(random.randint(1000, 9999))])
 
     assert resolved == Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
 
 
-def test_Given_unparsable_service_argv__When_resolved__Then_path_falls_back_to_tempdir_without_raising(faker: Faker):
-    resolved = resolve_crash_dump_path(["--port", faker.word()])
+def test_Given_unparsable_service_argv__When_resolved__Then_path_falls_back_to_tempdir_without_raising():
+    resolved = resolve_crash_dump_path(["--port", str(uuid4())])
 
     assert resolved == Path(tempfile.gettempdir()) / f"{APP_NAME}-{CRASH_DUMP_FILENAME}"
 
 
-def test_Given_traceback_text__When_crash_dump_written__Then_file_contains_traceback(tmp_path: Path, faker: Faker):
+def test_Given_traceback_text__When_crash_dump_written__Then_file_contains_traceback(tmp_path: Path):
     crash_dump_path = tmp_path / CRASH_DUMP_FILENAME
-    traceback_text = faker.text()
+    traceback_text = str(uuid4())
 
     wrote = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback_text)
 
@@ -39,11 +40,9 @@ def test_Given_traceback_text__When_crash_dump_written__Then_file_contains_trace
     assert crash_dump_path.read_text(encoding="utf-8") == traceback_text
 
 
-def test_Given_unwritable_path__When_crash_dump_written__Then_returns_false_without_raising(
-    tmp_path: Path, faker: Faker
-):
-    crash_dump_path = tmp_path / faker.word() / CRASH_DUMP_FILENAME
-    traceback_text = faker.text()
+def test_Given_unwritable_path__When_crash_dump_written__Then_returns_false_without_raising(tmp_path: Path):
+    crash_dump_path = tmp_path / str(uuid4()) / CRASH_DUMP_FILENAME
+    traceback_text = str(uuid4())
 
     wrote = write_crash_dump(crash_dump_path=crash_dump_path, traceback_text=traceback_text)
 

--- a/template/{% if has_backend %}backend{% endif %}/tests/{% if install_as_windows_service %}windows_service{% endif %}/test_service_lifecycle.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/{% if install_as_windows_service %}windows_service{% endif %}/test_service_lifecycle.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import httpx
 import pytest
+from backend_api.entrypoint.crash_dump import CRASH_DUMP_FILENAME
 from backend_api.jinja_constants import APP_NAME
 
 from ..e2e.app_bootup import EXE_FILE_PATH
@@ -19,9 +20,6 @@ _SC_TIMEOUT = 10
 _STOP_TIMEOUT = 30
 _CRASH_DUMP_POLL_TIMEOUT = 60
 _EXE = str(EXE_FILE_PATH)
-# Mirrors CRASH_DUMP_FILENAME in backend_api.win_service; not imported because win_service.py
-# imports pywin32 at module top-level, which is not installed on Linux dev machines.
-_CRASH_DUMP_FILENAME = "service-crash.log"
 _ERROR_SERVICE_SPECIFIC_ERROR = "1066"  # Windows WIN32_EXIT_CODE indicating app-specific failure
 
 
@@ -79,7 +77,7 @@ def installed_service(tmp_path: Path):
     port = get_random_open_port()
     log_folder = tmp_path / "service-logs"
     log_folder.mkdir()
-    crash_dump_path = log_folder / _CRASH_DUMP_FILENAME
+    crash_dump_path = log_folder / CRASH_DUMP_FILENAME
     _install_service(port=port, log_folder=log_folder)
     try:
         yield InstalledService(port=port, log_folder=log_folder, crash_dump_path=crash_dump_path)
@@ -179,7 +177,7 @@ class TestServiceWorkerCrash:
         port = get_random_open_port()
         log_folder = tmp_path / "service-logs"
         log_folder.mkdir()
-        crash_dump_path = log_folder / _CRASH_DUMP_FILENAME
+        crash_dump_path = log_folder / CRASH_DUMP_FILENAME
         _install_service(port=port, log_folder=log_folder, extra_runtime_args=["--log-level", bad_log_level])
         try:
             # SCM may report start success briefly before the worker thread crashes; ignore returncode.


### PR DESCRIPTION
## Why is this change necessary?

The Windows-service crash-dump smoke test (`TestServiceWorkerCrash::test_When_service_worker_crashes__Then_crash_dump_written_to_log_folder`) is intermittently flaky on the **Windows Service Smoke Tests** job. On a failing run, `service-crash.log` never appeared in the log folder within the 60s poll, while the sibling test using the identical fixture passed in the same run.

Event log from the failing run:

```
Event[1] ID 3: The instance's SvcRun() method failed
  Traceback (most recent call last):
    File "win32serviceutil.py", line 1077, in SvcRun
    File "win32serviceutil.py", line 1027, in ReportServiceStatus
  pywintypes.error: (6, 'SetServiceStatus', 'The handle is invalid.')
Event[0] ID 242: SetServiceStatus failed setting STOPPED status Error 6 - The handle is invalid.
```

Root cause: the crash dump was written from inside the worker thread's `except` block, which only runs once `SvcDoRun` has started the worker. On slow CI runners pywin32's own `SvcRun` can hit `ReportServiceStatus` with an already-invalid SCM status handle, so the worker `except` block never reaches `crash_dump_path.write_text(...)` and no dump is produced. pywin32 still surfaces the `SvcRun` exception to SCM as 1066, which is why `sc query` reported `WIN32_EXIT_CODE: 1066` even though the deliberate crash-dump path never executed. Neither of the crash handler's own `LogErrorMsg` calls appeared in the event log, confirming it never ran.

This is a timing-dependent pywin32/SCM startup race, not a defect introduced by any recent change to `win_service.py`.

## How does this change address the issue?

Crash-dump capture no longer depends on the SCM service-status handle being healthy:

1. **New pywin32-free module** `backend/src/backend_api/entrypoint/crash_dump.py` holding `CRASH_DUMP_FILENAME`, `resolve_crash_dump_path` and `write_crash_dump`, extracted out of `win_service.py`. Because it imports no pywin32, it is importable and unit-testable on Linux.
2. **Outermost guard in `SvcRun`.** The crash-dump path is resolved once up front from the service argv, then `super().SvcRun()` is wrapped so ANY unhandled exception — startup, status reporting, or `SvcDoRun` itself — writes a dump before re-raising. The re-raise keeps pywin32 reporting `ERROR_SERVICE_SPECIFIC_ERROR` (1066) to SCM. The write is skipped when a dump already exists, so the invalid-handle `ReportServiceStatus` traceback cannot clobber a genuine worker traceback already on disk.
3. **Dump write decoupled from event-log and status reporting.** The worker `except` block now only captures the traceback; the main service thread writes the dump first and unconditionally, then attempts `LogErrorMsg` and `ReportServiceStatus`. A failing `ReportServiceStatus` can no longer prevent the dump file.

The existing contract is unchanged: a worker-config crash writes `service-crash.log` containing the trigger value into `--log-folder`, and surfaces to SCM as 1066.

## What side effects does this change have?

None



## How is this change tested?

Downstream repo (unit tests of changes, and running CI pipeline several times and seeing no flakiness)


