### PR TITLE
Copier update: better mutex / caching in CI

### DIFF
--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152
+_commit: v0.0.152-4-g8c8064ea
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152-7-g92b68ad6
+_commit: v0.0.152-8-g860e92bf
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152-9-gc691eea8
+_commit: v0.0.153
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152-5-g74eff1ab
+_commit: v0.0.152-7-g92b68ad6
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152-4-g8c8064ea
+_commit: v0.0.152-5-g74eff1ab
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.config/.copier-answers.yml
+++ b/.config/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.152-8-g860e92bf
+_commit: v0.0.152-9-gc691eea8
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 copier_answers_directory: .config
 description: A web app that is hosted within a local intranet. Nuxt frontend, python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,5 +60,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): e2237380 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 603c7384 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,5 +60,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 603c7384 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): b1b84da4 # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -61,7 +61,7 @@ def main():
             # invoke installer in a pwsh process
             _ = subprocess.run(  # noqa: S603 # this is all our own input
                 [
-                    pwsh,  # type: ignore[reportPossiblyUnboundVariable] # this matches the conditional above that defines pwsh
+                    pwsh,
                     "-NoProfile",
                     "-NonInteractive",
                     "-Command",

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -18,7 +18,7 @@ UV_VERSION = "0.12.3"
 PNPM_VERSION = "11.21.0"
 COPIER_VERSION = "==9.17.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "==0.3.3"
-PRE_COMMIT_VERSION = "4.5.1"
+PRE_COMMIT_VERSION = "4.6.2"
 GITHUB_WINDOWS_RUNNER_BIN_PATH = r"C:\Users\runneradmin\.local\bin"
 INSTALL_SSM_PLUGIN_BY_DEFAULT = False
 parser = argparse.ArgumentParser(description="Install CI tooling for the repo")

--- a/.github/reusable_workflows/build-docker-image.yaml
+++ b/.github/reusable_workflows/build-docker-image.yaml
@@ -127,14 +127,7 @@ jobs:
           echo "Image name without slashes: ${IMAGE_NAME_NO_SLASHES}"
           echo "full_image_tag=${{ inputs.repository }}/${{ inputs.image_name }}:context-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ inputs.push-role-name != 'no-push' }}
-        uses: ben-z/gh-action-mutex@1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10
-        with:
-          branch: mutex-${{ inputs.repository }}-${{ inputs.image_name }}
-        timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
-
-      - name: Test if docker image exists
+      - name: Test if docker image exists # deliberately before the mutex; describe-images is a read, so it is safe to run concurrently
         if: ${{ inputs.push-role-name != 'no-push' }}
         id: check-if-exists
         run: |
@@ -148,24 +141,55 @@ jobs:
             echo "status=notfound" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
+        if: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }} # only serialize when this job may have to build and push a new image
+        uses: ben-z/gh-action-mutex@1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10
+        with:
+          branch: mutex-${{ inputs.repository }}-${{ inputs.image_name }}
+        timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
+
+      - name: Re-test if docker image exists # another job may have pushed this exact build context while we waited on the mutex
+        if: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }}
+        id: recheck-if-exists
+        run: |
+          BUILD_HASH=${{ steps.calculate-build-context-hash.outputs.build_context_tag }}
+          echo Checking for : $BUILD_HASH
+          if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids=imageTag=$BUILD_HASH; then \
+            echo "Image was found in ECR"; \
+            echo "status=found" >> $GITHUB_OUTPUT
+          else \
+            echo "Image was not found in ECR"; \
+            echo "status=notfound" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Resolve whether the image needs building # collapses the two probes into the single status the rest of the job keys off
+        if: ${{ inputs.push-role-name != 'no-push' }}
+        id: image-status
+        run: |
+          if [ "${{ steps.check-if-exists.outputs.status }}" = "found" ]; then
+            echo "status=found" >> $GITHUB_OUTPUT
+          else
+            echo "status=${{ steps.recheck-if-exists.outputs.status }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Pull existing image to package as artifact
-        if: ${{ inputs.save-as-artifact && steps.check-if-exists.outputs.status == 'found' }}
+        if: ${{ inputs.save-as-artifact && steps.image-status.outputs.status == 'found' }}
         run: |
           docker pull ${{ steps.calculate-build-context-hash.outputs.full_image_tag }}
 
       - name: Set up Docker Buildx
-        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.check-if-exists.outputs.status == 'notfound' }}
+        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.image-status.outputs.status == 'notfound' }}
         uses: docker/setup-buildx-action@v4.0.0
         with:
           version: v0.33.0
 
       - name: Build Docker Image
-        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.check-if-exists.outputs.status == 'notfound' }}
+        if: ${{ (inputs.save-as-artifact && inputs.push-role-name == 'no-push') || steps.image-status.outputs.status == 'notfound' }}
         uses: docker/build-push-action@v7.1.0
         with:
           context: ${{ inputs.context }}
           build-contexts: ${{ inputs.build-contexts }}
-          push: ${{ inputs.push-role-name != 'no-push' && steps.check-if-exists.outputs.status == 'notfound' }}
+          push: ${{ inputs.push-role-name != 'no-push' && steps.image-status.outputs.status == 'notfound' }}
           load: ${{ inputs.save-as-artifact }} # make the image available later for the `docker save` step
           tags: ${{ steps.calculate-build-context-hash.outputs.full_image_tag }}
 

--- a/.github/reusable_workflows/build-docker-image.yaml
+++ b/.github/reusable_workflows/build-docker-image.yaml
@@ -217,6 +217,11 @@ jobs:
       - name: Add tag for Production
         if: ${{ inputs.push-role-name != 'no-push' && inputs.tag-for-production }}
         run: |
+          # Unlike the git sha tag above, a concurrent ImageAlreadyExistsException is deliberately left fatal here.
+          # This step only runs from deploy workflows, which are not expected to overlap for the same image, so a
+          # duplicate put-image points at something unexpected about how the deploy was triggered and should be loud
+          # rather than swallowed. Note that PRODUCTION_CONTEXT_TAG keys on the build context hash rather than the
+          # commit, so two commits that leave the build context unchanged do share a tag.
           aws ecr batch-get-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag=${{ steps.calculate-build-context-hash.outputs.build_context_tag }} --query 'images[].imageManifest' --output text > manifest.json
           PRODUCTION_CONTEXT_TAG="production--${{ steps.calculate-build-context-hash.outputs.build_context_tag }}"
           if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag="$PRODUCTION_CONTEXT_TAG" > /dev/null 2>&1; then
@@ -239,6 +244,9 @@ jobs:
             echo "Invalid release-tag: '$RELEASE_TAG'. Must start with alphanumeric or underscore and contain only alphanumerics, dots, hyphens, underscores (max 128 chars)."
             exit 1
           fi
+          # This check is an intentional immutability guard rather than a concurrency one: reusing a version number is a
+          # human mistake worth failing on. A concurrent ImageAlreadyExistsException below is likewise left fatal, since
+          # release workflows are not expected to run twice at once for the same tag.
           if aws ecr describe-images --region ${{ steps.parse_ecr_url.outputs.aws_region }} --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag="$RELEASE_TAG" > /dev/null 2>&1; then
             echo "Release tag '$RELEASE_TAG' already exists in ECR repository '${{ inputs.image_name }}'. Release tags are immutable; pick a new version or delete the existing tag if this was unintended."
             exit 1

--- a/.github/reusable_workflows/build-docker-image.yaml
+++ b/.github/reusable_workflows/build-docker-image.yaml
@@ -201,7 +201,17 @@ jobs:
             echo "Tag $GIT_SHA_TAG already exists in ECR, skipping"
           else
             aws ecr batch-get-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-ids imageTag=${{ steps.calculate-build-context-hash.outputs.build_context_tag }} --query 'images[].imageManifest' --output text > manifest.json
-            aws ecr put-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-tag "$GIT_SHA_TAG" --image-manifest file://manifest.json
+            # Every job on the push path tags the git sha, and jobs that find their image already in ECR no longer serialize on the mutex,
+            # so another job can apply this same tag between the check above and the put below. ECR reports that as
+            # ImageAlreadyExistsException, which by definition means the tag already points at this exact manifest, so it is safe to ignore.
+            # ImageTagAlreadyExistsException (a different manifest on an immutable repository) is a real conflict and still fails the step.
+            if ! aws ecr put-image --registry-id=${{ steps.parse_ecr_url.outputs.aws_account_id }} --repository-name=${{ inputs.image_name }} --image-tag "$GIT_SHA_TAG" --image-manifest file://manifest.json 2> put-image-error.txt; then
+              cat put-image-error.txt
+              if ! grep -q 'ImageAlreadyExistsException' put-image-error.txt; then
+                exit 1
+              fi
+              echo "Tag $GIT_SHA_TAG was applied concurrently by another job, nothing to do"
+            fi
           fi
 
       - name: Add tag for Production

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -189,22 +189,34 @@ jobs:
           git add .
           git status
 
+      - name: Compute Pre-commit cache key # must run after the instantiated template is in place, since hashFiles reads its .pre-commit-config.yaml
+        run: |
+          echo "CACHE_RESTORE_KEY=${{ matrix.os }}-${{ matrix.python-version }}-build-cache-pre-commit-hooks-" >> "$GITHUB_ENV"
+          echo "CACHE_KEY=${{ matrix.os }}-${{ matrix.python-version }}-build-cache-pre-commit-hooks-${{ hashFiles('.pre-commit-config.yaml') }}" >> "$GITHUB_ENV"
+
+      - name: Restore Pre-commit hooks cache # no mutex needed; concurrent cache reads are safe, only writes cause trouble
+        id: cache-probe
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
+
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
+        if: ${{ runner.os != 'Windows' && steps.cache-probe.outputs.cache-hit != 'true' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14. Only serialize when this job will have to write a new cache entry.
         uses: ben-z/gh-action-mutex@1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10
         with:
           branch: mutex-venv-${{ matrix.os }}-${{ matrix.python-version }}
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
-      - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.5
-        env:
-          cache-name: cache-pre-commit-hooks
+      - name: Re-restore Pre-commit hooks cache # another job may have created the exact-key cache while we waited on the mutex
+        id: cache-recheck
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' }}
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-build-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-build-${{ env.cache-name }}-
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
 
       - name: Run pre-commit
         run: |
@@ -216,6 +228,13 @@ jobs:
             git --no-pager diff
             exit $PRE_COMMIT_EXIT_CODE
           fi
+
+      - name: Save Pre-commit hooks cache
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' && steps.cache-recheck.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}
 
       - name: Upload pre-commit log if failure
         if: ${{ failure() }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -61,22 +61,34 @@ jobs:
           skip-installing-ssm-plugin-manager: true
           skip-installing-pulumi-cli: true
 
+      - name: Compute Pre-commit cache key # must run after checkout, since hashFiles needs the file on disk
+        run: |
+          echo "CACHE_RESTORE_KEY=ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-cache-pre-commit-hooks-" >> "$GITHUB_ENV"
+          echo "CACHE_KEY=ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-cache-pre-commit-hooks-${{ hashFiles('.pre-commit-config.yaml') }}" >> "$GITHUB_ENV"
+
+      - name: Restore Pre-commit hooks cache # no mutex needed; concurrent cache reads are safe, only writes cause trouble
+        id: cache-probe
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
+
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
+        if: ${{ runner.os != 'Windows' && steps.cache-probe.outputs.cache-hit != 'true' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14. Only serialize when this job will have to write a new cache entry.
         uses: ben-z/gh-action-mutex@1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10
         with:
           branch: mutex-venv-ubuntu-24.04-py${{ inputs.python-version }}-nodejs-${{ inputs.node-version }}
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
-      - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.5
-        env:
-          cache-name: cache-pre-commit-hooks
+      - name: Re-restore Pre-commit hooks cache # another job may have created the exact-key cache while we waited on the mutex
+        id: cache-recheck
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' }}
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
-          key: ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
 
       - name: Run pre-commit
         run: |
@@ -87,3 +99,10 @@ jobs:
             git --no-pager diff
             exit $PRE_COMMIT_EXIT_CODE
           fi
+
+      - name: Save Pre-commit hooks cache
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' && steps.cache-recheck.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 # You are welcome to make changes to this file in your repo if they are custom to your project,
 # but if the change should be shared with other projects, please backport it to the template repo.
 # =====================================================================================================
-minimum_pre_commit_version: 4.3.0
+minimum_pre_commit_version: 4.5.0
 # run `pre-commit autoupdate --freeze` to update all hooks
 default_install_hook_types: [pre-commit, post-checkout]
 repos:

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -23,7 +23,7 @@ class ContextUpdater(ContextHook):
         context["pnpm_version"] = "11.21.0"
         context["npm_version"] = "11.13.0"
         context["nvm_version"] = "0.40.5"
-        context["pre_commit_version"] = "4.5.1"
+        context["pre_commit_version"] = "4.6.2"
         context["pytest_version"] = ">=9.1.1"
         context["pytest_randomly_version"] = ">=4.1.0"
         context["pytest_cov_version"] = ">=7.1.0"
@@ -103,7 +103,7 @@ class ContextUpdater(ContextHook):
 
         context["gha_checkout"] = "v6.0.2"
         context["gha_setup_python"] = "v6.2.0"
-        context["gha_cache"] = "v5.0.5"
+        context["gha_cache"] = "v6.1.0"
         context["gha_upload_artifact"] = "v7.0.1"
         context["gha_download_artifact"] = "v8.0.1"
         context["gha_github_script"] = "v7.0.1"

--- a/template/.devcontainer/install-ci-tooling.py.jinja
+++ b/template/.devcontainer/install-ci-tooling.py.jinja
@@ -54,7 +54,7 @@ def main():
             # invoke installer in a pwsh process
             _ = subprocess.run(  # noqa: S603 # this is all our own input
                 [
-                    pwsh,  # type: ignore[reportPossiblyUnboundVariable] # this matches the conditional above that defines pwsh
+                    pwsh,
                     "-NoProfile",
                     "-NonInteractive",
                     "-Command",

--- a/template/.github/workflows/pre-commit.yaml
+++ b/template/.github/workflows/pre-commit.yaml
@@ -61,22 +61,34 @@ jobs:
           skip-installing-ssm-plugin-manager: true
           skip-installing-pulumi-cli: true
 
+      - name: Compute Pre-commit cache key # must run after checkout, since hashFiles needs the file on disk
+        run: |
+          echo "CACHE_RESTORE_KEY=ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-cache-pre-commit-hooks-" >> "$GITHUB_ENV"
+          echo "CACHE_KEY=ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-cache-pre-commit-hooks-${{ hashFiles('.pre-commit-config.yaml') }}" >> "$GITHUB_ENV"
+
+      - name: Restore Pre-commit hooks cache # no mutex needed; concurrent cache reads are safe, only writes cause trouble
+        id: cache-probe
+        uses: actions/cache/restore@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
+
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
-        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
+        if: ${{ runner.os != 'Windows' && steps.cache-probe.outputs.cache-hit != 'true' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14. Only serialize when this job will have to write a new cache entry.
         uses: ben-z/gh-action-mutex@1ebad517141198e08d47cf72f3c0975316620a65 # v1.0.0-alpha.10
         with:
           branch: mutex-venv-ubuntu-24.04-py${{ inputs.python-version }}-nodejs-${{ inputs.node-version }}
         timeout-minutes: 8  # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
 
-      - name: Cache Pre-commit hooks
-        uses: actions/cache@v5.0.5
-        env:
-          cache-name: cache-pre-commit-hooks
+      - name: Re-restore Pre-commit hooks cache # another job may have created the exact-key cache while we waited on the mutex
+        id: cache-recheck
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' }}
+        uses: actions/cache/restore@v6.1.0
         with:
           path: ${{ env.PRE_COMMIT_HOME }}
-          key: ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ubuntu-24.04-py${{ inputs.python-version }}-node-${{ inputs.node-version}}-${{ env.cache-name }}-
+          key: ${{ env.CACHE_KEY }}
+          restore-keys: ${{ env.CACHE_RESTORE_KEY }}
 
       - name: Run pre-commit
         run: |
@@ -87,3 +99,10 @@ jobs:
             git --no-pager diff
             exit $PRE_COMMIT_EXIT_CODE
           fi
+
+      - name: Save Pre-commit hooks cache
+        if: ${{ steps.cache-probe.outputs.cache-hit != 'true' && steps.cache-recheck.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v6.1.0
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: ${{ env.CACHE_KEY }}

--- a/template/.pre-commit-config.yaml.jinja
+++ b/template/.pre-commit-config.yaml.jinja
@@ -1,4 +1,4 @@
-{% raw %}minimum_pre_commit_version: 4.2.0
+{% raw %}minimum_pre_commit_version: 4.5.0
 # run `pre-commit autoupdate --freeze` to update all hooks
 default_install_hook_types: [pre-commit, post-checkout]
 repos:

--- a/template/frontend/package.json.jinja
+++ b/template/frontend/package.json.jinja
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@{% endraw %}{{ pnpm_version }}{% raw %}",
   "scripts": {
     "type-check": "vue-tsc --noEmit",
-    "lint": "eslint . --fix",
+    "lint": "eslint . --fix --fix-type problem,suggestion,layout",
     "build": "nuxt build",
     "comment-about-dev-no-fork": "sometimes it seems needed, other times it seems to work with it...more info https://github.com/nuxt/cli/issues/181",
     "dev": "nuxt dev --no-fork",{% endraw %}{% if has_backend %}{% raw %}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/openapi_problem_responses.py
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/openapi_problem_responses.py
@@ -1,5 +1,7 @@
+from collections.abc import Mapping
 from http import HTTPStatus
 from typing import Any
+from typing import NamedTuple
 
 from .fast_api_exception_handlers import ProblemDetails
 
@@ -7,11 +9,29 @@ PROBLEM_DETAILS_REF = "#/components/schemas/ProblemDetails"
 PROBLEM_JSON_MEDIA_TYPE = "application/problem+json"
 
 
+class ProblemExample(NamedTuple):
+    """One named alternative for a status code that several distinct failures can produce.
+
+    Carries only the parts that vary between them; the surrounding ``ProblemDetails`` envelope is filled
+    in by :func:`problem_response` so every example stays a valid instance of the schema it sits under.
+    """
+
+    summary: str
+    detail: str
+
+
+def _problem_body(*, status_code: int, detail: str, instance: str) -> dict[str, Any]:  # pyrefly: ignore[explicit-any] # model_dump returns dict[str, Any]; see the note on problem_response's return type
+    return ProblemDetails(
+        title=HTTPStatus(status_code).phrase, status=status_code, detail=detail, instance=instance
+    ).model_dump(mode="json", by_alias=True)
+
+
 def problem_response(
     status_code: int,
     description: str,
     *,
     instance: str = "about:blank",
+    examples: Mapping[str, ProblemExample] | None = None,
 ) -> dict[int | str, dict[str, Any]]:  # pyrefly: ignore[explicit-any] # OpenAPI response fragments are heterogeneous nested JSON; JsonValue would force every consumer to narrow through the union to reach a leaf
     """Build an OpenAPI ``responses`` entry documenting a ``ProblemDetails`` error.
 
@@ -23,12 +43,21 @@ def problem_response(
     show a body that matches this response (e.g. a 400 titled "Bad Request") instead of the generic
     field-level example rendered from a bare ``ProblemDetails`` schema ref. Pass ``instance`` to point the
     example at the route's real path.
+
+    When one status code covers several distinct failures, pass ``examples`` instead: each
+    :class:`ProblemExample` becomes a named entry, expanded here into a full ``ProblemDetails`` body.
+    Expanding them here rather than at the call site is what keeps them valid against the schema they sit
+    under — a hand-written ``{"detail": ...}`` omits the required ``title``, ``status`` and ``instance``.
     """
-    example = ProblemDetails(
-        title=HTTPStatus(status_code).phrase, status=status_code, detail=description, instance=instance
-    )
-    content: dict[str, Any] = {  # pyrefly: ignore[explicit-any] # matches the return type above
-        "schema": {"$ref": PROBLEM_DETAILS_REF},
-        "example": example.model_dump(mode="json", by_alias=True),
-    }
+    content: dict[str, Any] = {"schema": {"$ref": PROBLEM_DETAILS_REF}}  # pyrefly: ignore[explicit-any] # matches the return type above
+    if examples is None:
+        content["example"] = _problem_body(status_code=status_code, detail=description, instance=instance)
+    else:
+        named_examples: dict[str, Any] = {}  # pyrefly: ignore[explicit-any] # matches the return type above
+        for name, example in examples.items():
+            named_examples[name] = {
+                "summary": example.summary,
+                "value": _problem_body(status_code=status_code, detail=example.detail, instance=instance),
+            }
+        content["examples"] = named_examples
     return {status_code: {"description": description, "content": {PROBLEM_JSON_MEDIA_TYPE: content}}}

--- a/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}strawberry_router.py{% endif %}
+++ b/template/{% if has_backend %}backend{% endif %}/src/backend_api/{% if backend_uses_graphql %}strawberry_router.py{% endif %}
@@ -21,9 +21,8 @@ class AddErrorTrace(SchemaExtension):
     def _process_result(self, result: ExecutionResult) -> None:
         assert isinstance(result, ExecutionResult), f"Expected ExecutionResult, got {type(result)}"
 
-        assert result.errors is not None, (
-            "Strawberry is expected to populate an empty list rather than None when a query succeeds"
-        )
+        if result.errors is None:
+            return
         for error in result.errors:
             trace_id = str(uuid7())
             error.message += f" (Error trace id: {trace_id})"

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/test_openapi_problem_responses.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/test_openapi_problem_responses.py
@@ -1,9 +1,10 @@
+from uuid import uuid4
+
 from backend_api.openapi_problem_responses import PROBLEM_DETAILS_REF
 from backend_api.openapi_problem_responses import PROBLEM_JSON_MEDIA_TYPE
 from backend_api.openapi_problem_responses import ProblemExample
 from backend_api.openapi_problem_responses import problem_response
 from httpx import codes
-from uuid import uuid4
 
 
 def test_Given_status_and_description__Then_responses_entry_is_keyed_by_status_code() -> None:

--- a/template/{% if has_backend %}backend{% endif %}/tests/unit/test_openapi_problem_responses.py
+++ b/template/{% if has_backend %}backend{% endif %}/tests/unit/test_openapi_problem_responses.py
@@ -1,7 +1,9 @@
 from backend_api.openapi_problem_responses import PROBLEM_DETAILS_REF
 from backend_api.openapi_problem_responses import PROBLEM_JSON_MEDIA_TYPE
+from backend_api.openapi_problem_responses import ProblemExample
 from backend_api.openapi_problem_responses import problem_response
 from httpx import codes
+from uuid import uuid4
 
 
 def test_Given_status_and_description__Then_responses_entry_is_keyed_by_status_code() -> None:
@@ -35,3 +37,37 @@ def test_Given_explicit_instance__Then_example_points_at_it() -> None:
     ][PROBLEM_JSON_MEDIA_TYPE]["example"]
 
     assert example["instance"] == "/api/widgets/7"
+
+
+def test_Given_named_examples__Then_content_carries_an_entry_per_name() -> None:
+    examples = {
+        "missing_widget": ProblemExample(summary=str(uuid4()), detail=str(uuid4())),
+        "missing_bin": ProblemExample(summary=str(uuid4()), detail=str(uuid4())),
+    }
+
+    responses = problem_response(codes.NOT_FOUND, "Widget not found", examples=examples)
+
+    content = responses[codes.NOT_FOUND]["content"][PROBLEM_JSON_MEDIA_TYPE]
+
+    assert set(content["examples"]) == set(examples)
+    assert content["examples"]["missing_widget"]["summary"] == examples["missing_widget"].summary
+    assert content["examples"]["missing_bin"]["summary"] == examples["missing_bin"].summary
+
+
+def test_Given_named_examples_and_an_explicit_instance__Then_each_value_is_a_complete_problem_details_body() -> None:
+    detail = str(uuid4())
+    instance = f"/api/widgets/{uuid4()}"
+
+    responses = problem_response(
+        codes.CONFLICT,
+        "Widget conflicts with another widget",
+        instance=instance,
+        examples={"conflicting_widget": ProblemExample(summary=str(uuid4()), detail=detail)},
+    )
+
+    value = responses[codes.CONFLICT]["content"][PROBLEM_JSON_MEDIA_TYPE]["examples"]["conflicting_widget"]["value"]
+
+    assert value["title"] == "Conflict"
+    assert value["status"] == codes.CONFLICT
+    assert value["detail"] == detail
+    assert value["instance"] == instance


### PR DESCRIPTION
Pull in upstream template changes


## How is this change tested?
Downstream repo


## Other

Updated the eslint command so that it doesn't automatically strip stale ignore directives (same behavior we have with ruff already)

Expanded the ability to send examples into the ProblemDescription helper

<!--
============== WARNING ==============================================================================
File is managed by copier template: gh:LabAutomationAndScreening/copier-base-template.git
See .config/.copier-managed-files.json for details.

You are welcome to make changes to this file in your repo if they are custom to your project,
but if the change should be shared with other projects, please backport it to the template repo.
=====================================================================================================
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API documentation can now display multiple named error examples, including summaries and complete problem details.
  - Error responses can include explicit instance references for clearer troubleshooting.

- **Bug Fixes**
  - Improved handling of GraphQL operations that complete without errors.

- **Chores**
  - Updated development tooling and pre-commit requirements.
  - Improved workflow caching and Docker image coordination to reduce redundant CI work.
  - Limited automatic lint fixes to safer issue categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->